### PR TITLE
Lower default teleport cost per meter to 0.01

### DIFF
--- a/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
+++ b/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
@@ -95,7 +95,7 @@ public static class PortInit
         ShipmentManager.ExpirationTime = plugin.Config.BindConfig("0 - Shipment Ports", "Expiration Time", 7200f, "Set time until expiration, 3600 = 1 hour", synced: true);
         PortUI.UseTeleportTab = plugin.Config.BindConfig("0 - Shipment Ports", "Teleport To Ports", Toggle.On, "If on, players can teleport to ports", synced: true);
         PortUI.UseTeleportTab.SettingChanged += PortUI.OnUseTeleportTabChange;
-        PortUI.TeleportCostPerMeter = plugin.Config.BindConfig("0 - Shipment Ports", "Teleport Cost Per Meter", 0.5f, "Coins charged per meter when teleporting. Set to 0 for free teleports. Default 0.5 = 1 coin per 2 meters", synced: true);
+        PortUI.TeleportCostPerMeter = plugin.Config.BindConfig("0 - Shipment Ports", "Teleport Cost Per Meter", 0.01f, "Coins charged per meter when teleporting. Set to 0 for free teleports. Default 0.01 = 1 coin per 100 meters", synced: true);
     }
 
     private static void SetupPort()


### PR DESCRIPTION
## Summary
- Change default teleport cost from 0.5 to 0.01 coins per meter (1 coin per 100 meters instead of 1 coin per 2 meters)

## Test plan
- [ ] Fresh install confirms new default
- [ ] Existing configs with explicit value are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)