### PR TITLE
Add All Rights Reserved license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,6 +21,12 @@ including uploading to Thunderstore, Nexus Mods, GitHub, or any other
 platform, by any party other than the copyright holder is strictly
 prohibited without prior written consent.
 
+Contributions: Notwithstanding the above, you may fork this repository on
+GitHub and submit pull requests proposing changes. By submitting a pull
+request, you agree that your contribution is licensed to the copyright
+holder under the same terms as this LICENSE, and may be incorporated into
+the Work at the copyright holder's discretion.
+
 THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+All Rights Reserved
+
+Copyright (c) 2026 jneb802
+
+All rights reserved.
+
+This software and its source code, assets, configuration files, and
+documentation (the "Work") are the exclusive property of the copyright
+holder. No part of the Work may be reproduced, distributed, republished,
+uploaded, posted, modified, sublicensed, sold, or used to create derivative
+works, in whole or in part, in any form or by any means, without the prior
+written consent of the copyright holder.
+
+Permission is granted to end users to download and use the Work solely for
+personal, non-commercial gameplay purposes through distribution channels
+authorized by the copyright holder (such as the official Thunderstore
+release published by the copyright holder).
+
+Any redistribution, mirroring, repackaging, or republication of the Work,
+including uploading to Thunderstore, Nexus Mods, GitHub, or any other
+platform, by any party other than the copyright holder is strictly
+prohibited without prior written consent.
+
+THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT
+OF, OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS IN THE
+WORK.
+
+For licensing inquiries or permission requests, contact the copyright
+holder via the project's GitHub repository:
+https://github.com/jneb802/MoreWorldLocations_All


### PR DESCRIPTION
Adds a LICENSE file with All Rights Reserved terms.

- Reserves all rights to the copyright holder
- Permits end users to download and play through the official Thunderstore release
- Prohibits redistribution, mirroring, or republishing on any platform without prior written consent