### PR TITLE
Fix PTB ZoneSystem APIs

### DIFF
--- a/Dungeon_Castle/Src/AltarDoor.cs
+++ b/Dungeon_Castle/Src/AltarDoor.cs
@@ -91,9 +91,9 @@ namespace Forbidden_Catacombs
         {
             int prefabHash = prefabName.GetStableHashCode();
             
-            Vector2i sector = ZoneSystem.GetZone(position);
+            Vector2s sector = ZoneSystem.GetZone(position);
         
-            int sectorIndex = ZDOMan.instance.SectorToIndex(sector);
+            int sectorIndex = (int)ZoneSystem.SectorToIndex(sector).Sector;
         
             if (sectorIndex < 0 || sectorIndex >= ZDOMan.instance.m_objectsBySector.Length)
             {
@@ -128,4 +128,3 @@ namespace Forbidden_Catacombs
 
     }
 }
-

--- a/Dungeon_The Ritual/Src/AttachPuzzle.cs
+++ b/Dungeon_The Ritual/Src/AttachPuzzle.cs
@@ -77,9 +77,9 @@ public class AttachPuzzle : MonoBehaviour
     {
         int prefabHash = prefabName.GetStableHashCode();
         
-        Vector2i sector = ZoneSystem.GetZone(position);
+        Vector2s sector = ZoneSystem.GetZone(position);
     
-        int sectorIndex = ZDOMan.instance.SectorToIndex(sector);
+        int sectorIndex = (int)ZoneSystem.SectorToIndex(sector).Sector;
     
         if (sectorIndex >= 0 && sectorIndex < ZDOMan.instance.m_objectsBySector.Length)
         {
@@ -265,4 +265,3 @@ public class AttachPuzzle : MonoBehaviour
         public int puzzlePosition = new int();
     }
 }
-

--- a/More World Locations_AIO/Src/Ports/src/PortManager.cs
+++ b/More World Locations_AIO/Src/Ports/src/PortManager.cs
@@ -47,7 +47,7 @@ public class PortManager : MonoBehaviour
     public void UpdatePortLocations()
     {
         if (!ZNet.instance || !ZNet.instance.IsServer() || !ZoneSystem.instance) return;
-        Dictionary<Vector2i, ZoneSystem.LocationInstance>.ValueCollection? allLocations = ZoneSystem.instance.GetLocationList();
+        var allLocations = ZoneSystem.instance.GetLocationList();
         List<ZoneSystem.LocationInstance> ports = allLocations.Where(location => location.m_location.m_group == "MWL_Ports").ToList();
         if (ports.Count == 0) return;
         More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug($"Registered {ports.Count} ports");


### PR DESCRIPTION
## Summary
- Let the AIO port manager use the PTB GetLocationList return type without hard-coding the old Vector2i dictionary key.
- Update Forbidden_Catacombs and Underground_Ruins sector lookup code from Vector2i/ZDOMan.SectorToIndex to the PTB Vector2s/ZoneSystem.SectorToIndex API.

## Validation
- Built the main AIO project against the PTB server assembly mirror:
  dotnet build MoreWorldLocations_All.sln /p:VALHEIM_INSTALL=/Users/benjmarston/Develop/valheim-ptb-server /p:BepInExPath="/Users/benjmarston/Library/Application Support/Steam/steamapps/common/Valheim/BepInEx" /p:BEPINEX_PATH="/Users/benjmarston/Library/Application Support/Steam/steamapps/common/Valheim/BepInEx"
- Deployed More_World_Locations_AIO.dll to Hetzner praetoris PTB test server.
- Confirmed deployed DLL SHA256: a270695ed353a1dbc55bfc09292da92540347745711f503897d5aa6034764f38.
- Restarted test server through mmcli-agent with 0 players online.

## Notes
- The two dungeon source fixes are included, but their legacy non-SDK project files do not currently build on this Mac: dotnet can be pointed at the .NET Framework reference assemblies, but Jotunn/YamlDotNet/package references do not resolve cleanly under those projects. They should still be built in the normal Windows/release environment before publishing dungeon DLLs.
- Dedicated-server validation covers the active AIO DLL; client-side PTB testing is still needed for location and port behavior.