### PR TITLE
Localize remaining port UI text

### DIFF
--- a/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
+++ b/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
@@ -140,7 +140,7 @@ public static class PortInit
             prefab.GetComponent<ZNetView>().m_persistent = false;
 
             // current size 10
-            Manifest manifest = new Manifest("Wooden Shipment", prefab.GetComponent<Container>());
+            Manifest manifest = new Manifest(LocalKeys.ManifestWoodenShipment, prefab.GetComponent<Container>());
             manifest.CostToShip = 50;
             manifest.Recipe.Add("Wood", 10);
             manifest.Recipe.Add("Resin", 5);
@@ -158,7 +158,7 @@ public static class PortInit
             prefab.GetComponent<ZNetView>().m_persistent = false;
 
             // current size 12
-            Manifest manifest = new Manifest("Barrel Shipment", prefab.GetComponent<Container>());
+            Manifest manifest = new Manifest(LocalKeys.ManifestBarrelShipment, prefab.GetComponent<Container>());
             manifest.CostToShip = 55;
             manifest.Recipe.Add("Wood", 10);
             manifest.Recipe.Add("BarrelRings", 1);
@@ -176,7 +176,7 @@ public static class PortInit
             prefab.GetComponent<ZNetView>().m_persistent = false;
 
             // current size 24
-            Manifest manifest = new Manifest("Fine Shipment", prefab.GetComponent<Container>());
+            Manifest manifest = new Manifest(LocalKeys.ManifestFineShipment, prefab.GetComponent<Container>());
             manifest.CostToShip = 100;
             manifest.Recipe.Add("FineWood", 10);
             manifest.Recipe.Add("Iron", 2);
@@ -195,7 +195,7 @@ public static class PortInit
             prefab.GetComponent<ZNetView>().m_persistent = false;
 
             // current size 32
-            Manifest manifest = new Manifest("Fuling Shipment", prefab.GetComponent<Container>());
+            Manifest manifest = new Manifest(LocalKeys.ManifestFulingShipment, prefab.GetComponent<Container>());
             manifest.CostToShip = 280;
             manifest.Recipe.Add("FineWood", 10);
             manifest.Recipe.Add("Tar", 2);
@@ -222,7 +222,7 @@ public static class PortInit
             // new size 40
             // this container has default items, remove
             container.m_defaultItems.m_drops.Clear();
-            Manifest manifest = new Manifest("Dvergr Shipment", prefab.GetComponent<Container>());
+            Manifest manifest = new Manifest(LocalKeys.ManifestDvergrShipment, prefab.GetComponent<Container>());
             manifest.CostToShip = 410;
             manifest.Recipe.Add("YggdrasilWood", 10);
             manifest.Recipe.Add("Copper", 2);

--- a/More World Locations_AIO/Src/Ports/src/LocalKeys.cs
+++ b/More World Locations_AIO/Src/Ports/src/LocalKeys.cs
@@ -41,6 +41,21 @@ public static class LocalKeys
     public static readonly string Capacity = "$label_capacity";
     public static readonly string CostToShip = "$label_cost_to_ship";
     public static readonly string DeliveryCollected = "$msg_delivery_collected";
+    public static readonly string PortsTooltipTopic = "$label_ports_tooltip";
+    public static readonly string ShipmentSingular = "$label_shipment_single";
+    public static readonly string DeliverySingular = "$label_delivery_single";
+    public static readonly string TutorialIntroduction = "$label_tutorial_introduction";
+    public static readonly string TutorialTextIntroduction = "$tutorial_introduction";
+    public static readonly string TutorialTextPort = "$tutorial_port";
+    public static readonly string TutorialTextManifest = "$tutorial_manifest";
+    public static readonly string TutorialTextShipment = "$tutorial_shipment";
+    public static readonly string TutorialTextDelivery = "$tutorial_delivery";
+    public static readonly string TutorialTextTeleport = "$tutorial_teleport";
+    public static readonly string ManifestWoodenShipment = "$manifest_wooden_shipment";
+    public static readonly string ManifestBarrelShipment = "$manifest_barrel_shipment";
+    public static readonly string ManifestFineShipment = "$manifest_fine_shipment";
+    public static readonly string ManifestFulingShipment = "$manifest_fuling_shipment";
+    public static readonly string ManifestDvergrShipment = "$manifest_dvergr_shipment";
 
     public static string ToKey(this ShipmentState state) => state switch
     {

--- a/More World Locations_AIO/Src/Ports/src/Port.cs
+++ b/More World Locations_AIO/Src/Ports/src/Port.cs
@@ -461,7 +461,7 @@ public class Port : MonoBehaviour, Interactable, Hoverable
                 string time = Shipment.FormatTime(remainingTime);
                 sb.AppendFormat("\n{3}: <color=orange>{0}</color> (<color=yellow>{1}</color>{2})", delivery.OriginPortName, delivery.State.ToKey(), string.IsNullOrEmpty(time) ? "" : $", {time}", LocalKeys.Origin);
             }
-            sb.Append($"\n\nShipments (<color=yellow>{shipments.Count}</color>): ");
+            sb.Append($"\n\n{LocalKeys.Shipments} (<color=yellow>{shipments.Count}</color>): ");
             foreach (Shipment? shipment in shipments)
             {
                 double remainingTime = shipment.State == ShipmentState.InTransit 

--- a/More World Locations_AIO/Src/Ports/src/PortUI.cs
+++ b/More World Locations_AIO/Src/Ports/src/PortUI.cs
@@ -916,7 +916,7 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
             Tooltip.m_anchor = transform.Find("TooltipAnchor").GetComponent<RectTransform>();
             Tooltip.m_fixedPosition = new Vector2(0f, 10f);
             Tooltip.m_tooltipPrefab = _tooltipPrefab;
-            Tooltip.m_topic = "MWL_Ports_Tooltip";
+            Tooltip.m_topic = Localization.instance.Localize(LocalKeys.PortsTooltipTopic);
         }
 
         public void Enable(bool enable) => Prefab.SetActive(enable);

--- a/More World Locations_AIO/Src/Ports/src/tutorials/PortTutorial.cs
+++ b/More World Locations_AIO/Src/Ports/src/tutorials/PortTutorial.cs
@@ -1,61 +1,28 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using System.Text;
-using More_World_Locations_AIO;
 
 namespace More_World_Locations_AIO.tutorials;
 
 public class PortTutorial
 {
-    private static readonly StringBuilder sb = new StringBuilder();
-
     internal static readonly List<PortTutorial> tutorials = new();
     public readonly string text;
     public readonly string label;
-    
-    private PortTutorial(string label, string resource) : this(label, LoadMarkdownFromAssembly(resource))
-    {
-    }
 
-    private PortTutorial(string label, List<string> lines)
+    private PortTutorial(string label, string text)
     {
         this.label = label;
-        sb.Clear();
-
-        foreach (string? line in lines)
-        {
-            sb.Append(line);
-            sb.Append('\n');
-        }
-        text = sb.ToString();
+        this.text = text;
         tutorials.Add(this);
     }
     
     public static void Setup()
     {
-        PortTutorial introTab = new PortTutorial("Introduction", "introduction.md");
-        PortTutorial portTab = new PortTutorial("Port", "port.md");
-        PortTutorial manifestTab = new PortTutorial("Manifest", "manifest.md");
-        PortTutorial shipmentTab = new PortTutorial("Shipment",  "shipment.md");
-        PortTutorial deliveryTab = new PortTutorial("Delivery",  "delivery.md");
-        PortTutorial teleportTab = new PortTutorial("Teleport", "teleport.md");
-    }
-
-    private static List<string> LoadMarkdownFromAssembly(string resourceName, string folder = "Src.Ports.src.tutorials")
-    {
-        Assembly assembly = Assembly.GetExecutingAssembly();
-        string path = $"{More_World_Locations_AIOPlugin.ModName}.{folder}.{resourceName}";
-        using Stream? stream = assembly.GetManifestResourceStream(path);
-        if (stream == null)
-            throw new FileNotFoundException($"Embedded resource '{resourceName}' not found in assembly '{assembly.FullName}'.");
-
-        using StreamReader reader = new StreamReader(stream);
-        List<string> lines = new List<string>();
-        while (!reader.EndOfStream)
-        {
-            lines.Add(reader.ReadLine() ?? string.Empty);
-        }
-        return lines;
+        tutorials.Clear();
+        new PortTutorial(LocalKeys.TutorialIntroduction, LocalKeys.TutorialTextIntroduction);
+        new PortTutorial(LocalKeys.Port, LocalKeys.TutorialTextPort);
+        new PortTutorial(LocalKeys.Manifest, LocalKeys.TutorialTextManifest);
+        new PortTutorial(LocalKeys.ShipmentSingular, LocalKeys.TutorialTextShipment);
+        new PortTutorial(LocalKeys.DeliverySingular, LocalKeys.TutorialTextDelivery);
+        new PortTutorial(LocalKeys.Teleport, LocalKeys.TutorialTextTeleport);
     }
 }

--- a/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
+++ b/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
@@ -77,6 +77,95 @@ label_required_to_defeat: Required to defeat
 label_capacity: Capacity
 label_cost_to_ship: Cost to Ship
 msg_delivery_collected: Delivery marked as collected
+label_ports_tooltip: Ports
+label_shipment_single: Shipment
+label_delivery_single: Delivery
+label_tutorial_introduction: Introduction
+manifest_wooden_shipment: Wooden Shipment
+manifest_barrel_shipment: Barrel Shipment
+manifest_fine_shipment: Fine Shipment
+manifest_fuling_shipment: Fuling Shipment
+manifest_dvergr_shipment: Dvergr Shipment
+
+# Port tutorials
+tutorial_introduction: |
+  Ports are locations scattered across the world that let you <color=orange>ship items</color> and <color=orange>teleport</color> between them. If this is the first port you've found, congratulations - you've begun your shipping journey! Ports become much more useful as you discover more of them in the world.
+
+  <color=orange><b>How it works</b></color>
+  <size=5>●</size> Find a port and talk to its <color=orange>Port Manager</color> to discover it - it will then appear as a destination at all other ports
+  <size=5>●</size> Buy a <color=orange>manifest</color> from the Port Manager. Manifests are the shipping chests you use to transport items between ports. You can purchase up to three manifests per shipment, and higher tiers unlock as you discover more advanced materials. Fill your manifest chests with the items you want to ship
+  <size=5>●</size> Once the chests are loaded, talk to the Port Manager again and use the <color=yellow>Port</color> tab to select a destination. There will be a shipment fee that scales with distance - pay the fee by clicking <color=yellow>[Send Shipment]</color> and your shipment will be on its way
+  <size=5>●</size> You can see the status of all your active shipments in the <color=yellow>Shipment</color> tab
+  <size=5>●</size> Travel to the destination port, open the <color=yellow>Delivery</color> tab, and once the shipment has arrived click collect - the chests will appear!
+
+  <color=yellow>Note:</color> Travel time is based on in-game time, not real-life time.
+
+  <color=orange><b>Tabs</b></color>
+  <size=5>●</size> <color=yellow>Port</color> - Browse discovered ports and send shipments
+  <size=5>●</size> <color=yellow>Manifest</color> - Purchase and manage shipping chests
+  <size=5>●</size> <color=yellow>Shipment</color> - Track outgoing shipments from this port
+  <size=5>●</size> <color=yellow>Delivery</color> - View and collect incoming deliveries
+  <size=5>●</size> <color=yellow>Teleport</color> - Fast travel between ports for a fee (if enabled in config)
+tutorial_port: |
+  The Port tab lists every port you've discovered. Use it to choose where to send your shipments.
+
+  <color=orange><b>Discovering Ports</b></color>
+  <size=5>●</size> Talk to the <color=orange>Port Manager</color> at any port to discover it
+  <size=5>●</size> Discovered ports appear as destinations at every other port you visit
+
+  <color=orange><b>Selecting a Destination</b></color>
+  <size=5>●</size> Click a port in the list to select it as your destination
+  <size=5>●</size> Hover over a port to see its tooltip:
+     <size=5>♦</size> Shipment cost (scales with distance)
+     <size=5>♦</size> Estimated time of arrival
+     <size=5>♦</size> Items currently loaded in your manifests
+     <size=5>♦</size> Active shipments and deliveries at that port
+
+  <color=orange><b>Sending a Shipment</b></color>
+  <size=5>●</size> Once you've loaded your manifests and selected a destination, click <color=yellow>[Send Shipment]</color>
+  <size=5>●</size> The shipping fee will be deducted from your inventory
+  <size=5>●</size> <color=yellow>Empty manifests cannot be sent</color>
+tutorial_manifest: |
+  Manifests are the shipping chests you use to transport items. Purchase them from the Manifest tab before sending a shipment.
+
+  <color=orange><b>Purchasing</b></color>
+  <size=5>●</size> Each manifest has a purchase cost shown at the bottom of its tooltip
+  <size=5>●</size> You can purchase up to <color=orange>three manifests</color> per shipment
+  <size=5>●</size> Higher-tier manifests unlock as you discover more advanced materials
+
+  <color=orange><b>Loading Items</b></color>
+  <size=5>●</size> Purchased manifests appear as containers near the Port Manager
+  <size=5>●</size> Open a manifest and fill it with the items you want to ship
+  <size=5>●</size> The tooltip shows each manifest's capacity and current contents
+
+  <color=yellow>Tip:</color> You don't need to fill every slot - send as many or as few items as you like, but manifests cannot be sent empty.
+tutorial_shipment: |
+  The Shipment tab shows all outgoing shipments from the <color=orange>current port</color>.
+
+  <color=orange><b>Shipment Details</b></color>
+  Each shipment entry displays:
+  <size=5>●</size> The items packed in each manifest
+  <size=5>●</size> The destination port
+  <size=5>●</size> Estimated time of arrival
+  <size=5>●</size> Current status (<color=yellow>In Transit</color> or <color=yellow>Delivered</color>)
+
+  <color=yellow>Note:</color> The Port tab also shows a summary of shipments per destination, but only the Shipment tab shows the full contents of each manifest.
+tutorial_delivery: |
+  The Delivery tab shows incoming shipments at the <color=orange>current port</color>.
+
+  <color=orange><b>Collecting a Delivery</b></color>
+  <size=5>●</size> When a shipment's status changes to <color=yellow>Delivered</color>, click it to collect
+  <size=5>●</size> The manifest chests will appear near the Port Manager with all your items inside
+  <size=5>●</size> Once you've emptied every chest, the containers disappear and the delivery is marked complete
+tutorial_teleport: |
+  The Teleport tab lets you fast travel directly to any discovered port.
+
+  <color=orange><b>How it Works</b></color>
+  <size=5>●</size> Select a destination and click <color=yellow>[Teleport]</color>
+  <size=5>●</size> The teleport fee scales with distance, similar to shipping costs
+  <size=5>●</size> You will arrive at the destination port instantly
+
+  <color=yellow>Note:</color> Teleporting is a config option and may be disabled by the server.
 
 # Port trader names
 trader_port_name_1: Halmar


### PR DESCRIPTION
## Summary
- route port tutorial labels and body text through the localization YAML
- localize manifest names shown in the manifest list/detail panel
- replace remaining hardcoded port tooltip strings with localization keys

## Verification
- ruby YAML parse check
- LocalKeys coverage check against localization YAML
- dotnet build