### PR TITLE
Add port runestone texts

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -136,6 +136,7 @@ namespace More_World_Locations_AIO
             Prefabs.AddAllPrefabs();
             LocationCustomPrefabs.AddMarbleJail1Prefabs();
             LocationCustomPrefabs.AddMarbleCliffAltar1Prefabs();
+            LocationCustomPrefabs.AddPortRunestonePrefabs();
             PortPrefabs.AddPortPrefabs();
 
             if (BepinexConfigs.EnableTraders.Value == PortInit.Toggle.On ||

--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -21,7 +21,7 @@ namespace More_World_Locations_AIO
     public class More_World_Locations_AIOPlugin : BaseUnityPlugin
     {
         internal const string ModName = "More_World_Locations_AIO";
-        internal const string ModVersion = "4.7.3";
+        internal const string ModVersion = "4.8.0";
         internal const string Author = "warpalicious";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";

--- a/More World Locations_AIO/Src/Utils/LocationCustomPrefabs.cs
+++ b/More World Locations_AIO/Src/Utils/LocationCustomPrefabs.cs
@@ -92,4 +92,26 @@ public class LocationCustomPrefabs
         }
         
     }
+
+    public static void AddPortRunestonePrefabs()
+    {
+        AddRunestone("MWL_Port1_Runestone1", "$mwl_port1_runestone", "$mwl_port1_runestone_text");
+        AddRunestone("MWL_Port2_Runestone1", "$mwl_port2_runestone", "$mwl_port2_runestone_text");
+        AddRunestone("MWL_Port3_Runestone1", "$mwl_port3_runestone", "$mwl_port3_runestone_text");
+        AddRunestone("MWL_Port4_Runestone1", "$mwl_port4_runestone", "$mwl_port4_runestone_text");
+        AddRunestone("MWL_Port5_Runestone1", "$mwl_port5_runestone", "$mwl_port5_runestone_text");
+    }
+
+    private static void AddRunestone(string prefabName, string nameKey, string textKey)
+    {
+        GameObject runestone = Prefabs.AddRuneStonePrefab(prefabName, "RuneStone_Mistlands_bosshint");
+        if (runestone == null) return;
+
+        RuneStone rs = runestone.GetComponent<RuneStone>();
+        rs.m_name = nameKey;
+        rs.m_text = textKey;
+        rs.m_pinName = "";
+        rs.m_pinType = Minimap.PinType.None;
+        rs.m_locationName = "";
+    }
 }

--- a/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
+++ b/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
@@ -37,6 +37,22 @@ mwl_marblejail1_runestone_text: "They forgot me here. Years turned to decades. T
 mwl_marblecliffaltar1_runestone: Dangerous Acquisition
 mwl_marblecliffaltar1_runestone_text: "What rests upon the altar is not yours. It belongs to those who circle above, who wait in silence. Take it, and a deadly horn will break the silence of the mist."
 
+# Port Runestones
+mwl_port1_runestone: Drelthor's Theft
+mwl_port1_runestone_text: "Cursed be to Drelthor the Covetous, King of the Dvergr in the Golden Age. For it was he who so desired knowledge that stole Odin’s Eye from Mimir's Well. The desecrated waters poisoned Yggdrasil, causing shoots to fall to Valheim in sickness and incurring the wrath of Odin himself."
+
+mwl_port2_runestone: We Are Dvergr
+mwl_port2_runestone_text: "Cursed be to Drelthor the Covetous! Our great civilizations took a thousand years to build and moments to destroy. Our cities, trade hubs, fortresses and farms all laid waste by the forsaken. Why, then do we persist? To what end to we maintain our tiny fortresses and encampments in these hopeless times? Because we are Dvergr! And even the wrath of Odin will not end us. We will survive. We will rebuild. We will regain Odin’s favor. We will bring about a new golden age."
+
+mwl_port3_runestone: Seeds of a New Era
+mwl_port3_runestone_text: "Why maintain these ports – relics of a once great era long past? They serve no purpose save the occasional income from passing nomads. Because we shall need them when we rebuild! When the great Dvergr nations arise again, we will need trade and commerce! These are the seeds of a new era and they will flourish!\n\nOh, and cursed be to Drelthor the Covetous."
+
+mwl_port4_runestone: Kingdoms in Ruin
+mwl_port4_runestone_text: "Cursed be to Drelthor the Covetous, who plunged our prosperous Dvergr nations into ruin by angering Odin. The All-Father cast his most villainous forsaken and lost souls into our realm as punishment both for them and us. Our kingdoms crumbled. Our once-vibrant lands filled with mist and fire. Our people scattered and leaderless."
+
+mwl_port5_runestone: Drelthor's Lament
+mwl_port5_runestone_text: "I am Drelthor, one-time king of the Dvergr. In my arrogance I stole the eye of Odin and brought about our ruin. It is ironic that the Eye gave me wisdom to know I should never have stolen it. Would only that I could undo my transgression! But it is done. There is nothing left for me but to wander endlessly. For the Eye has also doomed me with immortality. So that I may watch the endless suffering of my people and the destruction of all I once ruled.\n\nCursed be to me."
+
 # Ports UI
 label_shipment: Shipments
 label_port: Port


### PR DESCRIPTION
## Summary
- register custom runestone prefabs for MWL_Port1 through MWL_Port5
- add localized titles and story text for all five port runestones
- hook port runestone registration into AIO initialization

## Validation
- YAML parsed successfully
- git diff --check
- dotnet build

Note: the port Unity prefabs still need matching JVLmock_MWL_PortX_Runestone1 placeholders placed in the assets for these registered prefabs to appear in-game.