### PR TITLE
Restrict port shipments to sender

### DIFF
--- a/More World Locations_AIO/Src/Ports/src/LocalKeys.cs
+++ b/More World Locations_AIO/Src/Ports/src/LocalKeys.cs
@@ -41,6 +41,7 @@ public static class LocalKeys
     public static readonly string Capacity = "$label_capacity";
     public static readonly string CostToShip = "$label_cost_to_ship";
     public static readonly string DeliveryCollected = "$msg_delivery_collected";
+    public static readonly string ShipmentNotOwned = "This shipment belongs to another player";
 
     public static string ToKey(this ShipmentState state) => state switch
     {

--- a/More World Locations_AIO/Src/Ports/src/Port.cs
+++ b/More World Locations_AIO/Src/Ports/src/Port.cs
@@ -203,6 +203,12 @@ public class Port : MonoBehaviour, Interactable, Hoverable
     public bool LoadDelivery(Shipment delivery)
     {
         EnsureInitialized();
+        if (!delivery.CanAccess(Player.m_localPlayer))
+        {
+            if (m_currentHumanoid != null) m_currentHumanoid.Message(MessageHud.MessageType.Center, LocalKeys.ShipmentNotOwned);
+            return false;
+        }
+
         if (m_containers.HasItems())
         {
             if (m_currentHumanoid != null) m_currentHumanoid.Message(MessageHud.MessageType.Center, LocalKeys.FailedToLoadDelivery);
@@ -433,15 +439,19 @@ public class Port : MonoBehaviour, Interactable, Hoverable
             // and details about port
             portID = new ShipmentManager.PortID(zdo.GetString(PortVars.GUID), zdo.GetString(PortVars.Name));
             position = zdo.GetPosition();
-            deliveries = ShipmentManager.GetDeliveries(portID.GUID);
-            shipments = ShipmentManager.GetShipments(portID.GUID);
+            deliveries = ShipmentManager.GetDeliveries(portID.GUID)
+                .Where(delivery => delivery.CanAccess(Player.m_localPlayer))
+                .ToList();
+            shipments = ShipmentManager.GetShipments(portID.GUID)
+                .Where(shipment => shipment.CanAccess(Player.m_localPlayer))
+                .ToList();
         }
         public void Reload()
         {
             deliveries.Clear();
             shipments.Clear();
-            deliveries.AddRange(ShipmentManager.GetDeliveries(portID.GUID));
-            shipments.AddRange(ShipmentManager.GetShipments(portID.GUID));
+            deliveries.AddRange(ShipmentManager.GetDeliveries(portID.GUID).Where(delivery => delivery.CanAccess(Player.m_localPlayer)));
+            shipments.AddRange(ShipmentManager.GetShipments(portID.GUID).Where(shipment => shipment.CanAccess(Player.m_localPlayer)));
             ShipmentManager.OnShipmentsUpdated -= Reload;
         }
         

--- a/More World Locations_AIO/Src/Ports/src/PortUI.cs
+++ b/More World Locations_AIO/Src/Ports/src/PortUI.cs
@@ -610,6 +610,7 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
         ClearLeftPanel();
         if (m_currentPort == null) return;
         List<Shipment> shipments = ShipmentManager.GetShipments(m_currentPort.m_portID.GUID)
+            .Where(shipment => shipment.CanAccess(Player.m_localPlayer))
             .OrderBy(shipment => shipment.ArrivalTime)
             .ToList();
         foreach (Shipment shipment in shipments) AddShipment(shipment);
@@ -620,7 +621,9 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
     {
         ClearLeftPanel();
         if (m_currentPort == null) return;
-        List<Shipment> deliveries = ShipmentManager.GetDeliveries(m_currentPort.m_portID.GUID);
+        List<Shipment> deliveries = ShipmentManager.GetDeliveries(m_currentPort.m_portID.GUID)
+            .Where(delivery => delivery.CanAccess(Player.m_localPlayer))
+            .ToList();
         foreach(Shipment? delivery in deliveries) AddDelivery(delivery);
         ResizeLeftList();
     }
@@ -664,7 +667,7 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
             m_selectedDelivery = shipment;
             Description.SetName(shipment.OriginPortName);
             Description.SetBodyText(shipment.GetTooltip());
-            MainButton.interactable = shipment.State == ShipmentState.Delivered;
+            MainButton.interactable = shipment.State == ShipmentState.Delivered && shipment.CanAccess(Player.m_localPlayer);
             float timer = 0f;
             OnUpdate = dt =>
             {

--- a/More World Locations_AIO/Src/Ports/src/Shipment.cs
+++ b/More World Locations_AIO/Src/Ports/src/Shipment.cs
@@ -18,6 +18,9 @@ public class Shipment
     public ShipmentState State = ShipmentState.Pending;
     public double ArrivalTime;
     public double ExpirationTime;
+    public long SenderPeerID;
+    public long SenderPlayerID;
+    public string SenderName = string.Empty;
     public List<ShipmentItem> Items = new List<ShipmentItem>();
 
     [NonSerialized] public bool IsValid = true;
@@ -30,6 +33,11 @@ public class Shipment
         DestinationPortID = destinationPort.GUID;
         DestinationPortName = destinationPort.Name;
         ShipmentID = Guid.NewGuid().ToString();
+        if (Player.m_localPlayer != null)
+        {
+            SenderPlayerID = Player.m_localPlayer.GetPlayerID();
+            SenderName = Player.m_localPlayer.GetPlayerName();
+        }
         ArrivalTime = ZNet.instance.GetTimeSeconds() + CalculateDistanceTime(distance);
         ExpirationTime = ArrivalTime + ShipmentManager.ExpirationTime.Value;
     }
@@ -62,10 +70,34 @@ public class Shipment
         State = data.State;
         ArrivalTime = data.ArrivalTime;
         ExpirationTime = data.ExpirationTime;
+        SenderPeerID = data.SenderPeerID;
+        SenderPlayerID = data.SenderPlayerID;
+        SenderName = data.SenderName;
         Items = data.Items;
-        ShipmentManager.Shipments[ShipmentID] = this;
-        ShipmentManager.UpdateShipments();
     }
+
+    public void SetServerSender(long senderPeerID, string senderName)
+    {
+        SenderPeerID = senderPeerID;
+        SenderName = senderName;
+    }
+
+    public bool CanAccess(Player? player)
+    {
+        if (IsLegacyShipment()) return true;
+        if (player == null) return false;
+        if (SenderPlayerID != 0L) return player.GetPlayerID() == SenderPlayerID;
+        return !string.IsNullOrEmpty(SenderName) && player.GetPlayerName() == SenderName;
+    }
+
+    public bool CanServerAccess(long senderPeerID, string senderName)
+    {
+        if (IsLegacyShipment()) return true;
+        if (SenderPeerID != 0L) return SenderPeerID == senderPeerID;
+        return !string.IsNullOrEmpty(SenderName) && SenderName == senderName;
+    }
+
+    private bool IsLegacyShipment() => SenderPeerID == 0L && SenderPlayerID == 0L && string.IsNullOrEmpty(SenderName);
     
     public void SendToServer()
     {
@@ -73,6 +105,9 @@ public class Shipment
         if (ZNet.instance && ZNet.instance.IsServer())
         {
             // if local client is server, then simply register to shipments, and update
+            SetServerSender(
+                ZRoutedRpc.instance != null ? ZRoutedRpc.instance.GetServerPeerID() : 0L,
+                Player.m_localPlayer != null ? Player.m_localPlayer.GetPlayerName() : SenderName);
             ShipmentManager.Shipments[ShipmentID]  = this;
             ShipmentManager.UpdateShipments();
         }

--- a/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
+++ b/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
@@ -288,10 +288,14 @@ public class ShipmentManager : MonoBehaviour
     public static void RPC_ServerReceiveShipment(long sender, string senderName, string serializedShipment)
     {
         Shipment newShipment = new Shipment(serializedShipment);
+        newShipment.SetServerSender(sender, senderName);
         More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug(newShipment.IsValid // make sure that the shipment is deserialized correctly
             ? $"Shipment from {senderName} registered!"
             : $"Shipment from {senderName} is invalid");
-        if (newShipment.IsValid) UpdateShipments();
+        if (!newShipment.IsValid) return;
+
+        Shipments[newShipment.ShipmentID] = newShipment;
+        UpdateShipments();
     }
 
     public static void RequestShipments()
@@ -310,14 +314,20 @@ public class ShipmentManager : MonoBehaviour
 
     public static void RPC_ServerShipmentCollected(long sender, string senderName, string shipmentID)
     {
-        if (!Shipments.Remove(shipmentID))
+        if (!Shipments.TryGetValue(shipmentID, out Shipment shipment))
         {
             More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug($"{senderName} said that they collected shipment {shipmentID}, but not found in dictionary");
+            return;
         }
-        else
+
+        if (!shipment.CanServerAccess(sender, senderName))
         {
-            UpdateShipments();
+            More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug($"{senderName} tried to collect shipment {shipmentID}, but does not own it");
+            return;
         }
+
+        Shipments.Remove(shipmentID);
+        UpdateShipments();
     }
 
     public struct PortID


### PR DESCRIPTION
## Summary
- stamp port shipments with sender identity when created/received
- hide shipments and deliveries from players who did not start them
- reject non-owner delivery collection on the server RPC path
- keep legacy shipments openable when no sender fields exist

## Validation
- `dotnet build MoreWorldLocations_All.sln`
- Built ownership branch at `109e51e`
- Valdev + Shadow + windowspc two-client validation:
  - master repro: `result=BUG_PRESENT`, `hasOwnershipGate=False`, `canAccess=True`, `loaded=True`
  - ownership branch: `result=FIXED`, `hasOwnershipGate=True`, `canAccess=False`, `loaded=False`
- Cleaned test shipment after validation