### PR TITLE
Fix port shipment expiration and stale collection

### DIFF
--- a/More World Locations_AIO/Src/Ports/src/Shipment.cs
+++ b/More World Locations_AIO/Src/Ports/src/Shipment.cs
@@ -148,7 +148,7 @@ public class Shipment
         {
             State = ShipmentState.InTransit;
         }
-        else if (currentTime <= ExpirationTime)
+        else if (ShipmentManager.ExpirationEnabled.Value is PortInit.Toggle.Off || currentTime <= ExpirationTime)
         {
             State = ShipmentState.Delivered;
         }

--- a/More World Locations_AIO/Src/Ports/src/Shipment.cs
+++ b/More World Locations_AIO/Src/Ports/src/Shipment.cs
@@ -90,11 +90,12 @@ public class Shipment
         return !string.IsNullOrEmpty(SenderName) && player.GetPlayerName() == SenderName;
     }
 
-    public bool CanServerAccess(long senderPeerID, string senderName)
+    public bool CanServerAccess(long senderPeerID, long senderPlayerID, string senderName)
     {
         if (IsLegacyShipment()) return true;
-        if (SenderPeerID != 0L) return SenderPeerID == senderPeerID;
-        return !string.IsNullOrEmpty(SenderName) && SenderName == senderName;
+        if (SenderPlayerID != 0L) return senderPlayerID != 0L && SenderPlayerID == senderPlayerID;
+        if (!string.IsNullOrEmpty(SenderName) && SenderName == senderName) return true;
+        return SenderPeerID != 0L && SenderPeerID == senderPeerID;
     }
 
     private bool IsLegacyShipment() => SenderPeerID == 0L && SenderPlayerID == 0L && string.IsNullOrEmpty(SenderName);
@@ -136,7 +137,8 @@ public class Shipment
         else
         {
             // else send shipment ID to server to manage
-            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(ShipmentManager.RPC_ServerShipmentCollected), Player.m_localPlayer.GetPlayerName(), ShipmentID);
+            string playerName = Player.m_localPlayer != null ? Player.m_localPlayer.GetPlayerName() : string.Empty;
+            ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.instance.GetServerPeerID(), nameof(ShipmentManager.RPC_ServerShipmentCollected), playerName, ShipmentID);
         }
     }
 

--- a/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
+++ b/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
@@ -151,17 +151,22 @@ public class ShipmentManager : MonoBehaviour
         if (!ZNet.instance) return;
         m_checkTransitTimer += dt;
         if (m_checkTransitTimer < m_checkTransitInterval) return;
-        List<Shipment> expiredShipments = new();
+        m_checkTransitTimer = 0f;
+        bool isServer = ZNet.instance.IsServer();
+        List<Shipment> expiredShipments = new List<Shipment>();
         foreach (Shipment shipment in Shipments.Values)
         {
             shipment.CheckTransit();
-            if (shipment.State is ShipmentState.Expired && ExpirationEnabled.Value is PortInit.Toggle.On) expiredShipments.Add(shipment);
+            if (isServer && shipment.State is ShipmentState.Expired && ExpirationEnabled.Value is PortInit.Toggle.On) expiredShipments.Add(shipment);
         }
-        // since everyone is running the timer, no need to get server to manage expiration
+
+        bool removedExpiredShipment = false;
         foreach (Shipment? shipment in expiredShipments)
         {
-            Shipments.Remove(shipment.ShipmentID);
+            removedExpiredShipment |= Shipments.Remove(shipment.ShipmentID);
         }
+
+        if (removedExpiredShipment) UpdateShipments();
     }
 
     public void OnClientUpdateShipments()
@@ -317,17 +322,29 @@ public class ShipmentManager : MonoBehaviour
         if (!Shipments.TryGetValue(shipmentID, out Shipment shipment))
         {
             More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug($"{senderName} said that they collected shipment {shipmentID}, but not found in dictionary");
+            UpdateShipments();
             return;
         }
 
-        if (!shipment.CanServerAccess(sender, senderName))
+        long senderPlayerID = GetSenderPlayerID(sender);
+        if (!shipment.CanServerAccess(sender, senderPlayerID, senderName))
         {
             More_World_Locations_AIOPlugin.More_World_Locations_AIOLogger.LogDebug($"{senderName} tried to collect shipment {shipmentID}, but does not own it");
+            UpdateShipments();
             return;
         }
 
         Shipments.Remove(shipmentID);
         UpdateShipments();
+    }
+
+    private static long GetSenderPlayerID(long sender)
+    {
+        if (!ZNet.instance || !ZNet.instance.IsServer() || ZDOMan.instance == null) return 0L;
+        ZNetPeer peer = ZNet.instance.GetPeer(sender);
+        if (peer == null || peer.m_characterID.IsNone()) return 0L;
+        ZDO character = ZDOMan.instance.GetZDO(peer.m_characterID);
+        return character != null ? character.GetLong(ZDOVars.s_playerID) : 0L;
     }
 
     public struct PortID


### PR DESCRIPTION
## Summary
- honor the shipment expiration toggle when updating shipment state
- make shipment collection use the stable player ID resolved by the server
- resync shipments when collection requests are stale or rejected
- make expired-shipment cleanup server-owned and persisted

## Testing
- dotnet build /Users/benjmarston/Develop/MoreWorldLocations_All/MoreWorldLocations_All.sln
- git diff --check
- deployed to local mmcli profile praetoris-season-6
- deployed to Valdev praetoris-season-6 and restarted
- manually collected the previously stuck shipment successfully