### PR TITLE
[codex] Fix disabled shrine network destroy

### DIFF
--- a/More World Locations_AIO/Src/Shrines/Shrine.cs
+++ b/More World Locations_AIO/Src/Shrines/Shrine.cs
@@ -23,13 +23,13 @@ public class Shrine : MonoBehaviour, Interactable, Hoverable
     
     public void Awake()
     {
+        znetView = GetComponent<ZNetView>();
+
         if (BepinexConfigs.EnableShrines.Value == PortInit.Toggle.Off)
         {
-            Destroy(gameObject);
             return;
         }
 
-        znetView = GetComponent<ZNetView>();
         ZDO zdo = znetView.GetZDO();
         if (znetView.IsOwner())
         {
@@ -103,6 +103,27 @@ public class Shrine : MonoBehaviour, Interactable, Hoverable
         hasBeenUsedOnce = zdo.GetBool("MWL_Shrine_FreeTag");
         
         Debug.Log("Shrine Awake: Loaded shrine config '" + shrineConfig.internalName + "'");
+    }
+
+    private void Start()
+    {
+        if (BepinexConfigs.EnableShrines.Value != PortInit.Toggle.Off)
+        {
+            return;
+        }
+
+        if (znetView == null)
+        {
+            znetView = GetComponent<ZNetView>();
+        }
+
+        if (znetView != null && ZNetScene.instance != null)
+        {
+            znetView.Destroy();
+            return;
+        }
+
+        Destroy(gameObject);
     }
 
     public bool Interact(Humanoid user, bool hold, bool alt)

--- a/More World Locations_AIO/Src/Waystones/Waystone.cs
+++ b/More World Locations_AIO/Src/Waystones/Waystone.cs
@@ -18,13 +18,13 @@ public class Waystone : MonoBehaviour, Interactable, Hoverable
 
     public void Awake()
     {
+        znetView = GetComponent<ZNetView>();
+
         if (BepinexConfigs.EnableWaystones.Value == PortInit.Toggle.Off)
         {
-            Destroy(gameObject);
             return;
         }
 
-        znetView = GetComponent<ZNetView>();
         ZDO zdo = znetView.GetZDO();
         if (znetView.IsOwner())
         {
@@ -86,6 +86,27 @@ public class Waystone : MonoBehaviour, Interactable, Hoverable
         }
         
         Debug.Log("Waystone Awake: Loaded waystone config '" + waystoneConfig.internalName + "'");
+    }
+
+    private void Start()
+    {
+        if (BepinexConfigs.EnableWaystones.Value != PortInit.Toggle.Off)
+        {
+            return;
+        }
+
+        if (znetView == null)
+        {
+            znetView = GetComponent<ZNetView>();
+        }
+
+        if (znetView != null && ZNetScene.instance != null)
+        {
+            znetView.Destroy();
+            return;
+        }
+
+        Destroy(gameObject);
     }
 
     public bool Interact(Humanoid user, bool hold, bool alt)


### PR DESCRIPTION
## Summary

Fixes disabled shrine and waystone feature handling so networked objects are removed through `ZNetView.Destroy()` instead of direct Unity `Destroy(gameObject)`.

## Root Cause

When `Enable Shrines` was `Off`, `Shrine.Awake()` directly destroyed `MWL_Shrine`. The prefab has a `ZNetView`, so it had already been registered in `ZNetScene.m_instances`. Direct Unity destruction left a stale `ZNetView` entry behind. When `ZNetScene.RemoveObjects()` later processed that stale entry, Valheim repeatedly logged `NullReferenceException` from `ZNetScene.RemoveObjects`.

`Waystone.Awake()` had the same pattern when waystones were disabled, so this PR fixes both paths.

## Validation

- Built locally with `dotnet build MoreWorldLocations_All.sln`.
- Reproduced on `valnet-client-01` in isolated profile `mwl-shrine-repro-20260613-085046` with:
  - `warpalicious-More_World_Locations_AIO` 4.9.0
  - `warpalicious-World_Gen_Accelerator` 1.0.0
  - MWL config `Enable Shrines = Off`
- Before fix: `cli_spawn_at MWL_Shrine 5000 50 5000 1 1 2` produced repeated `NullReferenceException` traces in `ZNetScene.RemoveObjects`.
- After fix: same disabled-shrine spawn command produced no matching `ZNetScene.RemoveObjects` error in the clean final log.

Evidence files on the Valnet client:

- `~/valnet-staging/results/mwl-shrine-repro-before-fix-2.log`
- `~/valnet-staging/results/mwl-shrine-repro-final.log`
