### PR TITLE
[codex] Disable manifest generation on startup

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -86,11 +86,12 @@ namespace More_World_Locations_AIO
             MinimapTraderIcons.LoadIcons();
             MinimapTraderIcons.BuildLocationSpriteData();
 
-            AssetBundles.BuildCombinedManifest(
-                Path.Combine(BepInEx.Paths.PluginPath, "warpalicious-More_World_Locations_AIO", "Bundles"),
-                "full",
-                LocationDB.GetAllAssetPaths().Concat(RoomDB.GetAllAssetPaths()).ToArray()
-            );
+            // Uncomment for one local game run to regenerate assetBundleManifest_full.
+            // AssetBundles.BuildCombinedManifest(
+            //     Path.Combine(BepInEx.Paths.PluginPath, "warpalicious-More_World_Locations_AIO", "Bundles"),
+            //     "full",
+            //     LocationDB.GetAllAssetPaths().Concat(RoomDB.GetAllAssetPaths()).ToArray()
+            // );
 
             LocationQuantityManager.LoadOrMigrateConfigs(Config);
             


### PR DESCRIPTION
## Summary

Disables the startup `AssetBundles.BuildCombinedManifest(...)` call so normal game runs and release builds use the packaged `assetBundleManifest_full` instead of regenerating it.

The helper block is left commented in place for the known manual workflow: uncomment it for one local game run when a fresh manifest needs to be generated, then comment it back out before shipping.

## Validation

- `dotnet build` passed with existing warnings and 0 errors.
- Confirmed there is no active `AssetBundles.BuildCombinedManifest(...)` call left under `Src` outside the helper method definition.
