### PR TITLE
[codex] Align 5.0.0 release metadata

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -39,7 +39,7 @@ namespace More_World_Locations_AIO
         
         public static GameObject root = null!;
         
-        private static readonly System.Version MinJotunnVersion = new System.Version(2, 28, 0);
+        private static readonly System.Version MinJotunnVersion = new System.Version(2, 29, 1);
 
         private const string MoreWorldTradersGUID = "warpalicious.More_World_Traders";
 
@@ -120,7 +120,7 @@ namespace More_World_Locations_AIO
             {
                 More_World_Locations_AIOLogger.LogError(
                     $"Failed to load YAML localizations: {ex.Message}. " +
-                    "Localized text will show as raw tokens. Please update Jotunn to 2.28.0 or newer.");
+                    $"Localized text will show as raw tokens. Please update Jotunn to {MinJotunnVersion} or newer.");
             }
             
             if (saveOnSet)

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -4,15 +4,16 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "warpalicious"
 name = "More_World_Locations_AIO"
-versionNumber = "4.5.0"
-description = "Adds 153 new POI locations with traders, ports, puzzles, and shrines to enhance Valheim's world exploration."
-websiteUrl = "https://discord.gg/KjgZ63VZv5"
+versionNumber = "5.0.0"
+description = "Adds 156 new POI locations including dungeons, traders, ports and much more to enhance Valheim's world exploration."
+websiteUrl = "https://discord.gg/3aaru2VyHJ"
 containsNsfwContent = false
 
 [package.dependencies]
 denikson-BepInExPack_Valheim = "5.4.2333"
 ValheimModding-JsonDotNET = "13.0.4"
-ValheimModding-Jotunn = "2.27.1"
+ValheimModding-YamlDotNet = "16.3.1"
+ValheimModding-Jotunn = "2.29.1"
 
 [build]
 icon = "./icon.png"


### PR DESCRIPTION
## Summary
- require Jotunn 2.29.1 in the runtime guard to match the 5.0.0 Thunderstore dependency
- align thunderstore.toml with the staged 5.0.0 release metadata
- add the YamlDotNet dependency to thunderstore.toml

## Validation
- `dotnet build 'More World Locations_AIO/More World Locations_AIO.csproj' -c Release` passed with existing warnings
- `python3` TOML parse confirmed version 5.0.0, Jotunn 2.29.1, and YamlDotNet 16.3.1
