### PR TITLE
[codex] Bump 5.0.1 release metadata

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -24,7 +24,7 @@ namespace More_World_Locations_AIO
     public class More_World_Locations_AIOPlugin : BaseUnityPlugin
     {
         internal const string ModName = "More_World_Locations_AIO";
-        internal const string ModVersion = "5.0.0";
+        internal const string ModVersion = "5.0.1";
         internal const string Author = "warpalicious";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![More World Locations AIO](https://i.imgur.com/Xd52Zfj.png)
 
 # More World Locations
-This mod massively enhances the world exploration component of Valheim by adding 153 new custom locations across all biomes and multiple new POI experiences.
+This mod massively enhances the world exploration component of Valheim by adding 180 new POI locations across all biomes, including 178 custom locations and 2 procedurally generated dungeons.
 
 ## Table of Contents
 - [Features](#features)
@@ -30,7 +30,8 @@ This mod massively enhances the world exploration component of Valheim by adding
 - [Credit & Thanks](#credit--thanks)
 
 ## Features
-- Adds 153 new custom locations across all biomes. Each spawns up to 20 times.
+- Adds 178 custom locations across all biomes. Each spawns up to 20 times.
+- Adds 2 procedurally generated dungeons, one in Black Forest and one in Swamp.
 - Adds Shipping Port locations to ship items and teleport between other discovered shipping port locations.
 - Adds Shrines that provide temporary buffs with randomized effects and durations.
 - Adds Waystones that mark dungeon locations on the map or reveal unexplored map area.

--- a/README_thunderstore.md
+++ b/README_thunderstore.md
@@ -1,10 +1,11 @@
 ![More World Locations AIO](https://i.imgur.com/Xd52Zfj.png)
 
 # More World Locations
-This mod massively enhances the world exploration component of Valheim by adding 153 new custom locations across all biomes and multiple new POI experiences.
+This mod massively enhances the world exploration component of Valheim by adding 180 new POI locations across all biomes, including 178 custom locations and 2 procedurally generated dungeons.
 
 ## Features
-- Adds 153 new custom locations across all biomes. Each spawns up to 20 times.
+- Adds 178 custom locations across all biomes. Each spawns up to 20 times.
+- Adds 2 procedurally generated dungeons, one in Black Forest and one in Swamp.
 - Adds Shipping Port locations to ship items and teleport between other discovered shipping port locations.
 - Adds Shrines that provide temporary buffs with randomized effects and durations.
 - Adds Waystones that mark dungeon locations on the map or reveal unexplored map area.


### PR DESCRIPTION
## Summary
- bump More World Locations AIO to 5.0.1
- restore the public location total from 4.9.0 and account for the two added dungeon locations
- update README and Thunderstore README wording to say 180 total POI locations: 178 custom locations plus 2 procedural dungeons

## Validation
- `dotnet build 'More World Locations_AIO/More World Locations_AIO.csproj' -c Release` passed with existing warnings
- `git diff --check` passed
