### PR TITLE
[codex] Add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,56 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master]
+
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review PR
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          use_sticky_comment: true
+          include_fix_links: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request for behavior bugs introduced by the diff.
+            Follow CLAUDE.md and REVIEW.md.
+
+            Focus on:
+            - Valheim/BepInEx/Jotunn integration risks
+            - server/client sync, ownership, RPCs, and cleanup
+            - embedded resources, YAML configs, asset bundle references, and localization
+            - Thunderstore/version/changelog consistency
+
+            Do not modify files, create commits, or push branches.
+            Do not attempt a full dotnet build on GitHub-hosted runners.
+            Always post one top-level PR comment, even if no blocking issues are found.
+          claude_args: |
+            --max-turns 8
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# More World Locations AIO
+
+This repository builds a BepInEx Valheim mod that adds custom world locations,
+ports, traders, shrines, waystones, totems, dungeons, loot, creatures, and YAML
+configuration.
+
+## Review Context
+
+- The main plugin project is `More World Locations_AIO/More World Locations_AIO.csproj`.
+- Shared code lives in `Common/`.
+- Dungeon subprojects live in `Dungeon_Castle/` and `Dungeon_The Ritual/`.
+- The main plugin targets `.NET Framework 4.8`, uses C# 10, and has nullable reference types enabled.
+- The build depends on local Valheim, BepInEx, publicized Valheim assemblies, Jotunn, ServerSync, and ILRepack.
+- GitHub-hosted runners usually do not have the Valheim install or publicized assemblies required for a full build.
+
+## Coding Rules
+
+- Prefer explicit C# type declarations over `var`.
+- Keep changes scoped to the requested behavior.
+- Do not remove or rename embedded assets, YAML resources, Thunderstore metadata, or bundle paths unless the PR is explicitly about packaging or assets.
+- Treat server/client synchronization, ZDO ownership, localization keys, YAML schema changes, and world-upgrade behavior as high-risk areas.
+- For user-facing config changes, verify defaults and migration behavior.
+
+## Review Expectations
+
+- Focus on behavior bugs introduced by the PR diff.
+- Cite specific files and lines for any finding.
+- Do not flag style-only issues unless they obscure behavior or maintainability.
+- Do not ask the author to run a full GitHub Actions build unless the workflow provides the required Valheim assemblies.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,38 @@
+# Review Instructions
+
+## Important Findings
+
+Mark a finding Important only when the PR likely introduces a real behavior bug,
+data loss, broken multiplayer behavior, asset/config breakage, release packaging
+breakage, or a compatibility problem with Valheim, BepInEx, Jotunn, or
+Thunderstore.
+
+Important examples:
+
+- Server/client state can diverge, duplicate, or fail to sync.
+- ZDO ownership, RPC routing, or network cleanup can run on the wrong peer.
+- A location, asset bundle, embedded resource, YAML file, localization key, or
+  Thunderstore dependency is renamed or moved without updating all references.
+- Config defaults or migrations can break existing worlds.
+- A release metadata change makes the package version, changelog, manifest, or
+  dependencies inconsistent.
+
+## Nit Findings
+
+Use Nit for small maintainability issues only when they are clearly introduced by
+the PR. Do not post more than five Nit comments. If there are more, summarize the
+extra items in the final comment instead of posting each one inline.
+
+## Do Not Report
+
+- Missing CI coverage for the full Valheim build. GitHub-hosted runners do not
+  have the local game assemblies this repo needs.
+- Formatting-only concerns unless they make the code hard to read.
+- Pre-existing issues outside the PR diff unless the PR makes them worse.
+- Speculative risks without a concrete code path and file/line evidence.
+
+## Final Comment
+
+Always post one top-level PR comment. Start with either `No blocking issues
+found.` or `Blocking issues found.` Then summarize the reviewed areas and list
+any Important findings first.


### PR DESCRIPTION
## Summary
- Add Claude project instructions for MWL review context
- Add REVIEW.md rules for PR review severity and output
- Add a Claude PR review workflow using CLAUDE_CODE_OAUTH_TOKEN

## Validation
- Parsed .github/workflows/claude-pr-review.yml as YAML
- Ran git diff --cached --check

## Notes
- The workflow skips draft PRs and fork PRs.
- A follow-up test PR will verify that Claude posts a review comment after this lands on master.