### PR TITLE
[codex] Post Claude review through direct CLI

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Claude review
+      - name: Prepare Claude app token
+        id: claude_app
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -37,23 +38,69 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request for behavior bugs introduced by the diff.
-            Follow CLAUDE.md and REVIEW.md.
-
-            Before posting, inspect the PR diff with `gh pr diff` and read any
-            changed files needed to understand the diff.
-
-            Focus on:
-            - Valheim/BepInEx/Jotunn integration risks
-            - server/client sync, ownership, RPCs, and cleanup
-            - embedded resources, YAML configs, asset bundle references, and localization
-            - Thunderstore/version/changelog consistency
-
-            Do not modify files, create commits, or push branches.
-            Do not attempt a full dotnet build on GitHub-hosted runners.
-            Post exactly one top-level PR comment using `gh pr comment`.
-            Start the comment with either `No blocking issues found.` or
-            `Blocking issues found.`
+            Authentication bootstrap only. Do not inspect files, modify files,
+            create commits, push branches, or post PR comments.
           claude_args: |
-            --max-turns 8
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)"
+            --max-turns 1
+
+      - name: Direct Claude review
+        env:
+          GH_TOKEN: ${{ steps.claude_app.outputs.github_token }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Claude GitHub App token was not available."
+            exit 1
+          fi
+
+          CLAUDE_BIN="${HOME}/.local/bin/claude"
+          if [ ! -x "${CLAUDE_BIN}" ]; then
+            echo "Claude CLI was not installed by the previous step."
+            exit 1
+          fi
+
+          mkdir -p .claude-review
+          gh pr view "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --json number,title,body,headRefName,baseRefName,commits,files \
+            > .claude-review/pr.json
+          gh pr diff "${PR_NUMBER}" --repo "${REPO}" > .claude-review/diff.patch
+
+          cat > .claude-review/prompt.md <<'PROMPT'
+          Review this pull request for behavior bugs introduced by the diff.
+          Follow CLAUDE.md and REVIEW.md.
+
+          Read these files before posting:
+          - .claude-review/pr.json
+          - .claude-review/diff.patch
+
+          Focus on:
+          - Valheim/BepInEx/Jotunn integration risks
+          - server/client sync, ownership, RPCs, and cleanup
+          - embedded resources, YAML configs, asset bundle references, and localization
+          - Thunderstore/version/changelog consistency
+
+          Do not modify files, create commits, or push branches.
+          Do not attempt a full dotnet build on GitHub-hosted runners.
+          Write exactly one PR review comment body.
+          Start with either `No blocking issues found.` or `Blocking issues found.`
+          PROMPT
+
+          "${CLAUDE_BIN}" -p "$(cat .claude-review/prompt.md)" \
+            --max-turns 6 \
+            --allowedTools "Read" \
+            > .claude-review/comment.md
+
+          if [ ! -s .claude-review/comment.md ]; then
+            echo "Claude produced an empty review comment."
+            exit 1
+          fi
+
+          gh pr comment "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --body-file .claude-review/comment.md


### PR DESCRIPTION
## Summary
- Use the Claude Action to obtain the Claude GitHub App token
- Run Claude Code directly against saved PR metadata and diff
- Post the generated review with the Claude App token

## Validation
- Parsed .github/workflows/claude-pr-review.yml as YAML
- Ran git diff --cached --check

## Reason
The Claude Action wrapper can authenticate and obtain the GitHub App token, but its SDK execution currently exits before any model call. This keeps the Claude App comment path while running Claude Code directly.