### PR TITLE
[codex] Post Claude review with workflow token

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Direct Claude review
         env:
-          GH_TOKEN: ${{ steps.claude_app.outputs.github_token }}
+          GH_TOKEN: ${{ github.token }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -54,7 +54,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Claude GitHub App token was not available."
+            echo "GitHub workflow token was not available."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Use the built-in workflow token for `gh` calls in the direct Claude review step
- Avoid using the Claude App token after the official action revokes it during cleanup

## Validation
- Parsed .github/workflows/claude-pr-review.yml as YAML
- Ran git diff --cached --check

## Notes
The review body is still generated by Claude Code. The PR comment author will be `github-actions[bot]`.