### PR TITLE
Allow Claude review bootstrap to continue

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Prepare Claude app token
         id: claude_app
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -41,7 +42,7 @@ jobs:
             Authentication bootstrap only. Do not inspect files, modify files,
             create commits, push branches, or post PR comments.
           claude_args: |
-            --max-turns 1
+            --max-turns 3
 
       - name: Direct Claude review
         env:
@@ -59,6 +60,9 @@ jobs:
           fi
 
           CLAUDE_BIN="${HOME}/.local/bin/claude"
+          if [ ! -x "${CLAUDE_BIN}" ]; then
+            CLAUDE_BIN="$(command -v claude || true)"
+          fi
           if [ ! -x "${CLAUDE_BIN}" ]; then
             echo "Claude CLI was not installed by the previous step."
             exit 1


### PR DESCRIPTION
## Summary
- allow the Claude Code bootstrap action to continue if its helper prompt exits early
- raise the helper prompt turn limit from 1 to 3
- fall back to finding the Claude CLI on PATH before failing the direct review step

## Validation
- ruby YAML parse for .github/workflows/claude-pr-review.yml
- git diff --check