### PR TITLE
Install Claude CLI directly for PR reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,7 +20,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-      id-token: write
 
     steps:
       - name: Check out PR
@@ -28,21 +27,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Prepare Claude app token
-        id: claude_app
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          include_fix_links: false
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Authentication bootstrap only. Do not inspect files, modify files,
-            create commits, push branches, or post PR comments.
-          claude_args: |
-            --max-turns 3
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@2.1.178
 
       - name: Direct Claude review
         env:
@@ -59,12 +45,9 @@ jobs:
             exit 1
           fi
 
-          CLAUDE_BIN="${HOME}/.local/bin/claude"
+          CLAUDE_BIN="$(command -v claude || true)"
           if [ ! -x "${CLAUDE_BIN}" ]; then
-            CLAUDE_BIN="$(command -v claude || true)"
-          fi
-          if [ ! -x "${CLAUDE_BIN}" ]; then
-            echo "Claude CLI was not installed by the previous step."
+            echo "Claude CLI was not installed."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- remove the Claude action bootstrap helper from the PR review workflow
- install the Claude Code CLI directly with npm
- drop the unused id-token permission

## Validation
- ruby YAML parse for .github/workflows/claude-pr-review.yml
- git diff --check