### PR TITLE
WARP-31 Configure Shipping Port cost per distance

### DIFF
--- a/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
+++ b/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
@@ -87,6 +87,7 @@ public static class PortInit
         
         // Server-synced configs (enforced by server for all clients)
         ShipmentManager.TransitByDistance = plugin.Config.BindConfig("0 - Shipment Ports", "Time Per Meter", 0.5f, "Set seconds per meter for shipment transit", synced: true);
+        ShipmentManager.ShippingCostPerMeter = plugin.Config.BindConfig("0 - Shipment Ports", "Shipping Cost Per Meter", ShipmentManager.DefaultShippingCostPerMeter, "Coins charged per meter when shipping items. Set to 0 for no distance surcharge. Default 0 preserves the existing manifest-only shipment cost. Negative, NaN, or infinite values fall back to the default.", synced: true);
         ShipmentManager.CurrencyConfig = plugin.Config.BindConfig("0 - Shipment Ports", "Shipment Currency", "Coins", "Set item prefab to use as currency to ship items", synced: true);
         ShipmentManager.CurrencyConfig.SettingChanged += (_, _) => ShipmentManager._currencyItem = null;
         ShipmentManager.OverrideTransitTime = plugin.Config.BindConfig("0 - Shipment Ports", "Override Transit Duration", Toggle.Off, "If on, transit time will be based off override instead of calculated based off distance", synced: true);

--- a/More World Locations_AIO/Src/Ports/src/Port.cs
+++ b/More World Locations_AIO/Src/Ports/src/Port.cs
@@ -256,12 +256,14 @@ public class Port : MonoBehaviour, Interactable, Hoverable
 
     public string GetHoverName() => Localization.instance.Localize(m_traderName);
 
-    public string GetTooltip()
+    public string GetTooltip() => GetTooltip(0f);
+
+    public string GetTooltip(float distance)
     {
         if (!m_containers.HasItems()) return "";
         StringBuilder sb = new StringBuilder();
         sb.Append($"{LocalKeys.CurrentShipments}:");
-        sb.Append($"\n{LocalKeys.Cost}: <color=orange>{ShipmentManager.CurrencyItem?.m_shared.m_name ?? "$item_coins"}</color> <color=yellow>x{m_containers.GetCost()}</color>");
+        sb.Append($"\n{LocalKeys.Cost}: <color=orange>{ShipmentManager.CurrencyItem?.m_shared.m_name ?? "$item_coins"}</color> <color=yellow>x{m_containers.GetCost(distance)}</color>");
         sb.Append($"\n{m_tempItems.GetTooltip()}");
         return sb.ToString();
     }
@@ -346,6 +348,14 @@ public class Port : MonoBehaviour, Interactable, Hoverable
                 manifests.Add(temp.manifest);
             }
             return manifests.Sum(i => i.CostToShip);
+        }
+
+        public int GetCost(float distance)
+        {
+            int manifestCost = GetCost();
+            int distanceCost = ShipmentManager.CalculateShippingDistanceCost(distance);
+            if (int.MaxValue - manifestCost < distanceCost) return int.MaxValue;
+            return manifestCost + distanceCost;
         }
 
         public List<Manifest> GetManifests()
@@ -468,6 +478,8 @@ public class Port : MonoBehaviour, Interactable, Hoverable
         }
         
         public float GetDistance(Player player) => Vector3.Distance(player.transform.position, position);
+
+        public float GetDistance(Port port) => global::Utils.DistanceXZ(port.transform.position, position);
 
         public string GetTooltip()
         {

--- a/More World Locations_AIO/Src/Ports/src/PortUI.cs
+++ b/More World Locations_AIO/Src/Ports/src/PortUI.cs
@@ -469,9 +469,9 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
 
     private bool CanShip()
     {
-        if (m_currentPort == null || !Player.m_localPlayer) return false;
+        if (m_currentPort == null || m_selectedDestination == null || !Player.m_localPlayer) return false;
         if (Player.m_localPlayer.NoCostCheat()) return true;
-        int cost = m_currentPort.m_containers.GetCost();
+        int cost = m_currentPort.m_containers.GetCost(m_selectedDestination.GetDistance(m_currentPort));
         string costItem = ShipmentManager.CurrencyItem?.m_shared.m_name ?? "$item_coins";
         int count = Player.m_localPlayer.GetInventory().CountItems(costItem);
         return count >= cost;
@@ -488,7 +488,7 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
                 if (m_selectedDestination == null) Hide();
                 else
                 {
-                    int shipmentCost = m_currentPort.m_containers.GetCost();
+                    int shipmentCost = m_currentPort.m_containers.GetCost(m_selectedDestination.GetDistance(m_currentPort));
                     string currencyItem = ShipmentManager.CurrencyItem?.m_shared.m_name ?? "$item_coins";
                     if (!Player.m_localPlayer.NoCostCheat() &&
                         Player.m_localPlayer.GetInventory().CountItems(currencyItem) < shipmentCost)
@@ -746,8 +746,9 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
         {
             item.SetSelected(true);
             m_selectedDestination = info;
-            Description.SetName($"<color=orange>{info.portID.Name}</color> ({(int)info.GetDistance(Player.m_localPlayer)}m)");
-            string containerTooltip = m_currentPort.GetTooltip(); // store it here, to keep this part static
+            float distance = info.GetDistance(m_currentPort);
+            Description.SetName($"<color=orange>{info.portID.Name}</color> ({(int)distance}m)");
+            string containerTooltip = m_currentPort.GetTooltip(distance); // store it here, to keep this part static
             OnSentShipment = () =>
             {
                 // for visual feedback that current shipment is sent
@@ -764,7 +765,7 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
             if (hasItems)
             {
                 Requirements.SetActive(true);
-                Requirements.LoadCost(m_currentPort.m_containers);
+                Requirements.LoadCost(m_currentPort.m_containers, distance);
                 Requirements.SetLevel(1.ToString());
             }
             
@@ -1071,11 +1072,11 @@ public class PortUI : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHa
             }
         }
 
-        public void LoadCost(Port.ContainerPlacement tempContainers)
+        public void LoadCost(Port.ContainerPlacement tempContainers, float distance)
         {
-            var total = tempContainers.GetCost();
-            var currency = ShipmentManager.CurrencyItem ?? ObjectDB.instance.GetItemPrefab("Coins").GetComponent<ItemDrop>().m_itemData;
-            var maxStack = currency.m_shared.m_maxStackSize;
+            int total = tempContainers.GetCost(distance);
+            ItemDrop.ItemData currency = ShipmentManager.CurrencyItem ?? ObjectDB.instance.GetItemPrefab("Coins").GetComponent<ItemDrop>().m_itemData;
+            int maxStack = currency.m_shared.m_maxStackSize;
 
             foreach (RequirementItem item in items)
             {

--- a/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
+++ b/More World Locations_AIO/Src/Ports/src/ShipmentManager.cs
@@ -18,7 +18,10 @@ namespace More_World_Locations_AIO;
 [PublicAPI]
 public class ShipmentManager : MonoBehaviour
 {
+    public const float DefaultShippingCostPerMeter = 0f;
+
     public static ConfigEntry<float> TransitByDistance = null!; 
+    public static ConfigEntry<float> ShippingCostPerMeter = null!;
     public static ConfigEntry<string> CurrencyConfig = null!;
     public static ConfigEntry<float> TransitTime = null!;
     public static ConfigEntry<PortInit.Toggle> OverrideTransitTime = null!;
@@ -228,6 +231,25 @@ public class ShipmentManager : MonoBehaviour
             shipments.Add(shipment);
         }
         return shipments;
+    }
+
+    public static float GetShippingCostPerMeter()
+    {
+        if (ShippingCostPerMeter == null) return DefaultShippingCostPerMeter;
+
+        float value = ShippingCostPerMeter.Value;
+        if (float.IsNaN(value) || float.IsInfinity(value) || value < 0f) return DefaultShippingCostPerMeter;
+        return value;
+    }
+
+    public static int CalculateShippingDistanceCost(float distance)
+    {
+        if (float.IsNaN(distance) || float.IsInfinity(distance) || distance <= 0f) return 0;
+
+        float cost = distance * GetShippingCostPerMeter();
+        if (float.IsNaN(cost) || float.IsInfinity(cost) || cost <= 0f) return 0;
+        if (cost >= int.MaxValue) return int.MaxValue;
+        return Mathf.FloorToInt(cost);
     }
     
     public static void ReadLocalFile()

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Shipping Ports are special coastal locations that introduce an item logistics sy
 - Purchase a shipping manifest (functions as a chest) from the port NPC.
 - Fill the manifest with the items you want to ship.
 - Select a destination from your list of discovered ports.
-- Pay the shipping cost in the configured currency (coins by default).
+- Pay the shipping cost in the configured currency (coins by default). The total is the manifest cost plus a distance surcharge.
 
 **Transit & Expiration:**
 - Shipments take time to arrive based on distance. The default rate is 2 seconds per meter (configurable). Transit time uses in-game time, not real-world time.
@@ -104,7 +104,9 @@ Shipping Ports are special coastal locations that introduce an item logistics sy
 
 **Teleportation:** Ports also support teleporting players between discovered ports. Teleport costs scale with distance. This feature is disabled by default and must be enabled in the config.
 
-**Configuration:** All port settings (transit time, currency, expiration, teleport costs) are server-synced and configurable. The ports feature can be disabled entirely in the config if you just want the base locations. Port data is stored in a folder titled `MWL_Ports` in the `BepInEx/Configs` folder.
+**Configuration:** All port settings (transit time, currency, shipment distance cost, expiration, teleport costs) are server-synced and configurable. The ports feature can be disabled entirely in the config if you just want the base locations. Port data is stored in a folder titled `MWL_Ports` in the `BepInEx/Configs` folder.
+
+**Shipping Cost Per Meter:** `Shipping Cost Per Meter` controls the distance surcharge in coins per meter. The default is `0`, preserving the existing manifest-only shipment cost. Valid values are `0` or higher; `0` removes the distance surcharge. Negative, NaN, or infinite values fall back to the default.
 
 ## Shrines
 Shrines are interactive objects that can appear inside MWL locations. They use the vanilla Ward prefab as their model (temporarily until a custom model is available).

--- a/README_thunderstore.md
+++ b/README_thunderstore.md
@@ -70,7 +70,7 @@ Shipping Ports are special coastal locations that introduce an item logistics sy
 - Purchase a shipping manifest (functions as a chest) from the port NPC.
 - Fill the manifest with the items you want to ship.
 - Select a destination from your list of discovered ports.
-- Pay the shipping cost in the configured currency (coins by default).
+- Pay the shipping cost in the configured currency (coins by default). The total is the manifest cost plus a distance surcharge.
 
 **Transit & Expiration:**
 - Shipments take time to arrive based on distance. The default rate is 2 seconds per meter (configurable). Transit time uses in-game time, not real-world time.
@@ -78,7 +78,9 @@ Shipping Ports are special coastal locations that introduce an item logistics sy
 
 **Teleportation:** Ports also support teleporting players between discovered ports. Teleport costs scale with distance. This feature is disabled by default and must be enabled in the config.
 
-**Configuration:** All port settings (transit time, currency, expiration, teleport costs) are server-synced and configurable. The ports feature can be disabled entirely in the config if you just want the base locations. Port data is stored in a folder titled `MWL_Ports` in the `BepInEx/Configs` folder.
+**Configuration:** All port settings (transit time, currency, shipment distance cost, expiration, teleport costs) are server-synced and configurable. The ports feature can be disabled entirely in the config if you just want the base locations. Port data is stored in a folder titled `MWL_Ports` in the `BepInEx/Configs` folder.
+
+**Shipping Cost Per Meter:** `Shipping Cost Per Meter` controls the distance surcharge in coins per meter. The default is `0`, preserving the existing manifest-only shipment cost. Valid values are `0` or higher; `0` removes the distance surcharge. Negative, NaN, or infinite values fall back to the default.
 
 ## Shrines
 Shrines are interactive objects that can appear inside MWL locations. They use the vanilla Ward prefab as their model (temporarily until a custom model is available).


### PR DESCRIPTION
## Summary

- Adds a server-synced `Shipping Cost Per Meter` config for Shipping Ports.
- Applies the configured distance surcharge to the Shipping Port UI requirement display and the send-payment check through the same total-cost path.
- Preserves existing installs by defaulting the new value to `0`, which keeps the current manifest-only shipment cost unless server owners opt in.
- Documents the setting name, default, units, valid range, and invalid-value fallback in the README files.

## Validation

- `dotnet build 'More World Locations_AIO/More World Locations_AIO.csproj'` passed with existing warnings and 0 errors.
- `git diff --check` passed.
- Code-level validation covered zero/negative/non-finite distance or config values through fallback guards.

Live Valheim server/client validation from WARP-31 remains pending, so this PR is draft.

Linear: WARP-31
Mac resume: `codex-sync WARP-31 nexus-1`
