### PR TITLE
WARP-8 Add MWL_Ruins7 terrain diagnostics

### DIFF
--- a/More World Locations_AIO/Src/Utils/MWLDebugCommands.cs
+++ b/More World Locations_AIO/Src/Utils/MWLDebugCommands.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace More_World_Locations_AIO;
 
@@ -193,5 +194,148 @@ public static class MWLCommands
             .Distinct()
             .OrderBy(n => n)
             .ToList() ?? new List<string>());
+
+        new Terminal.ConsoleCommand("mwl_location_diagnostics", "Report MWL location proxy and terrain modifier state. Usage: mwl_location_diagnostics <name>", args =>
+        {
+            if (args.Length < 2)
+            {
+                args.Context.AddString("Usage: mwl_location_diagnostics <location_name>");
+                return;
+            }
+
+            string searchName = args[1];
+            string lowerSearchName = searchName.ToLowerInvariant();
+            ZoneSystem zoneSystem = ZoneSystem.instance;
+
+            if (zoneSystem == null)
+            {
+                args.Context.AddString("ZoneSystem not available");
+                return;
+            }
+
+            List<ZoneSystem.ZoneLocation> zoneLocations = zoneSystem.m_locations
+                .Where(location => location.m_prefabName != null && location.m_prefabName.ToLowerInvariant().Contains(lowerSearchName))
+                .OrderBy(location => location.m_prefabName)
+                .ToList();
+
+            args.Context.AddString($"[MWLDiag] ZoneLocations matching '{searchName}': {zoneLocations.Count}");
+            foreach (ZoneSystem.ZoneLocation zoneLocation in zoneLocations)
+            {
+                args.Context.AddString(
+                    $"[MWLDiag] zone name={zoneLocation.m_prefabName} clearArea={zoneLocation.m_clearArea} exteriorRadius={zoneLocation.m_exteriorRadius:0.00} prefabValid={zoneLocation.m_prefab.IsValid} prefabLoaded={zoneLocation.m_prefab.IsLoaded}");
+            }
+
+            List<ZoneSystem.LocationInstance> instances = zoneSystem.m_locationInstances.Values
+                .Where(instance => instance.m_location?.m_prefabName != null && instance.m_location.m_prefabName.ToLowerInvariant().Contains(lowerSearchName))
+                .OrderBy(instance => instance.m_location.m_prefabName)
+                .ThenBy(instance => instance.m_position.x)
+                .ThenBy(instance => instance.m_position.z)
+                .ToList();
+
+            args.Context.AddString($"[MWLDiag] LocationInstances matching '{searchName}': {instances.Count}");
+            foreach (ZoneSystem.LocationInstance instance in instances)
+            {
+                args.Context.AddString(
+                    $"[MWLDiag] instance name={instance.m_location.m_prefabName} pos={FormatVector(instance.m_position)} placed={instance.m_placed}");
+            }
+
+            List<Vector3> instancePositions = instances
+                .Select(instance => instance.m_position)
+                .ToList();
+
+            List<LocationProxy> proxies = Object.FindObjectsByType<LocationProxy>(FindObjectsSortMode.None)
+                .Where(proxy => proxy != null && MatchesNameOrNearInstance(proxy.gameObject, lowerSearchName, instancePositions, 128f))
+                .OrderBy(proxy => proxy.name)
+                .ToList();
+
+            args.Context.AddString($"[MWLDiag] Active LocationProxy objects matching '{searchName}' by name or nearby instance: {proxies.Count}");
+            foreach (LocationProxy proxy in proxies)
+            {
+                ReportProxy(args, proxy);
+            }
+
+            List<GameObject> sceneObjects = Resources.FindObjectsOfTypeAll<GameObject>()
+                .Where(IsLoadedSceneObject)
+                .Where(gameObject => gameObject.name.ToLowerInvariant().Contains(lowerSearchName))
+                .OrderBy(gameObject => gameObject.name)
+                .Take(25)
+                .ToList();
+
+            args.Context.AddString($"[MWLDiag] Loaded scene objects matching '{searchName}' (first 25): {sceneObjects.Count}");
+            foreach (GameObject gameObject in sceneObjects)
+            {
+                TerrainModifier[] terrainModifiers = gameObject.GetComponentsInChildren<TerrainModifier>(true);
+                ZNetView[] zNetViews = gameObject.GetComponentsInChildren<ZNetView>(true);
+                args.Context.AddString(
+                    $"[MWLDiag] object name={gameObject.name} activeSelf={gameObject.activeSelf} activeInHierarchy={gameObject.activeInHierarchy} pos={FormatVector(gameObject.transform.position)} terrainModifiers={terrainModifiers.Length} activeTerrainModifiers={terrainModifiers.Count(IsActiveTerrainModifier)} znetViews={zNetViews.Length} activeZNetViews={zNetViews.Count(view => view != null && view.isActiveAndEnabled)}");
+
+                foreach (TerrainModifier terrainModifier in terrainModifiers)
+                {
+                    ReportTerrainModifier(args, terrainModifier);
+                }
+            }
+        }, optionsFetcher: () => ZoneSystem.instance?.m_locations
+            .Select(l => l.m_prefabName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Distinct()
+            .OrderBy(n => n)
+            .ToList() ?? new List<string>());
+    }
+
+    private static void ReportProxy(Terminal.ConsoleEventArgs args, LocationProxy proxy)
+    {
+        TerrainModifier[] terrainModifiers = proxy.GetComponentsInChildren<TerrainModifier>(true);
+        ZNetView[] zNetViews = proxy.GetComponentsInChildren<ZNetView>(true);
+
+        args.Context.AddString(
+            $"[MWLDiag] proxy name={proxy.name} activeSelf={proxy.gameObject.activeSelf} activeInHierarchy={proxy.gameObject.activeInHierarchy} pos={FormatVector(proxy.transform.position)} terrainModifiers={terrainModifiers.Length} activeTerrainModifiers={terrainModifiers.Count(IsActiveTerrainModifier)} znetViews={zNetViews.Length} activeZNetViews={zNetViews.Count(view => view != null && view.isActiveAndEnabled)}");
+
+        foreach (TerrainModifier terrainModifier in terrainModifiers)
+        {
+            ReportTerrainModifier(args, terrainModifier);
+        }
+    }
+
+    private static void ReportTerrainModifier(Terminal.ConsoleEventArgs args, TerrainModifier terrainModifier)
+    {
+        if (terrainModifier == null)
+        {
+            return;
+        }
+
+        args.Context.AddString(
+            $"[MWLDiag] terrain name={terrainModifier.name} activeSelf={terrainModifier.gameObject.activeSelf} activeInHierarchy={terrainModifier.gameObject.activeInHierarchy} enabled={terrainModifier.enabled} level={terrainModifier.m_level} levelOffset={terrainModifier.m_levelOffset:0.00} levelRadius={terrainModifier.m_levelRadius:0.00} smooth={terrainModifier.m_smooth} smoothRadius={terrainModifier.m_smoothRadius:0.00} pos={FormatVector(terrainModifier.transform.position)}");
+    }
+
+    private static bool IsActiveTerrainModifier(TerrainModifier terrainModifier)
+    {
+        return terrainModifier != null && terrainModifier.enabled && terrainModifier.gameObject.activeInHierarchy;
+    }
+
+    private static bool IsLoadedSceneObject(GameObject gameObject)
+    {
+        if (gameObject == null)
+        {
+            return false;
+        }
+
+        Scene scene = gameObject.scene;
+        return scene.IsValid() && scene.isLoaded;
+    }
+
+    private static bool MatchesNameOrNearInstance(GameObject gameObject, string lowerSearchName, List<Vector3> instancePositions, float maxDistance)
+    {
+        if (gameObject.name.ToLowerInvariant().Contains(lowerSearchName))
+        {
+            return true;
+        }
+
+        Vector3 position = gameObject.transform.position;
+        return instancePositions.Any(instancePosition => Vector3.Distance(position, instancePosition) <= maxDistance);
+    }
+
+    private static string FormatVector(Vector3 vector)
+    {
+        return $"({vector.x:0.00},{vector.y:0.00},{vector.z:0.00})";
     }
 }


### PR DESCRIPTION
## Summary

- Adds `mwl_location_diagnostics <name>` to MWL debug console commands.
- Reports matching `ZoneLocation` registration, generated `LocationInstance` positions, nearby or named active `LocationProxy` objects, child `TerrainModifier` state, and child `ZNetView` counts.
- The command is intended to validate `MWL_Ruins7` migration/proxy state after moving a 4.9.0-generated world to MWL 5.0.1 while preserving the Jotunn pickable duplication fix.

## Validation

- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Debug` passed with existing warnings and 0 errors.
- `git diff --check` passed.
- Static investigation confirmed Jotunn 2.29.1 location changes include PR 479 (`gameObject.SetActive(true)`) plus ZoneLocation radius/ClearArea sync changes; no MWL bundle/runtime fix was made in this PR.
- Live reproduction is not complete in this branch: nexus-1 has a candidate server world clone containing `MWL_Ruins7`, but the acceptance criteria require a running Valheim client to inspect client-side `LocationProxy` clones after a 4.9.0 to 5.0.1 migration.

Linear: WARP-8
Mac resume: `codex-sync WARP-8 nexus-1`