### PR TITLE
WARP-44 Fix Underground Ruins prefab registration

### DIFF
--- a/More World Locations_AIO/Src/Dungeons/Packs/UndergroundRuinsPack.cs
+++ b/More World Locations_AIO/Src/Dungeons/Packs/UndergroundRuinsPack.cs
@@ -57,7 +57,12 @@ public static class UndergroundRuinsPack
             new CustomPrefabSpec { Name = "BFD_CryptKey", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = "BFD_Modular6_Light", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = "BFD_Modular8_Puzzle_Light", Source = CustomPrefabSource.Bundled },
-            new CustomPrefabSpec { Name = "BFD_Modular12_Solution_Light", Source = CustomPrefabSource.Bundled },
+            new CustomPrefabSpec
+            {
+                Name = "BFD_Modular12_Solution_Light",
+                Source = CustomPrefabSource.VanillaClone,
+                VanillaSource = "BFD_Modular8_Puzzle_Light",
+            },
         };
 
         for (int i = 0; i < PuzzleCount; i++)

--- a/More World Locations_AIO/Src/Dungeons/Packs/UndergroundRuinsPack.cs
+++ b/More World Locations_AIO/Src/Dungeons/Packs/UndergroundRuinsPack.cs
@@ -57,6 +57,7 @@ public static class UndergroundRuinsPack
             new CustomPrefabSpec { Name = "BFD_CryptKey", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = "BFD_Modular6_Light", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = "BFD_Modular8_Puzzle_Light", Source = CustomPrefabSource.Bundled },
+            new CustomPrefabSpec { Name = "BFD_Modular12_Solution_Light", Source = CustomPrefabSource.Bundled },
         };
 
         for (int i = 0; i < PuzzleCount; i++)
@@ -100,7 +101,7 @@ public static class UndergroundRuinsPack
             "BFD_CryptKey",
             "BFD_Modular6_Light",
             "BFD_Modular8_Puzzle_Light",
-            "8_PuzzleStand",
+            "BFD_Modular12_Solution_Light",
             "DG_BlackForestDungeon",
         };
 

--- a/More World Locations_AIO/Src/Logging/ShaderWarningLogFilter.cs
+++ b/More World Locations_AIO/Src/Logging/ShaderWarningLogFilter.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using BepInEx.Logging;
+using HarmonyLib;
+
+namespace More_World_Locations_AIO.Logging;
+
+[HarmonyPatch]
+internal static class ShaderWarningLogFilter
+{
+    private const string ParticlesStandardUnlitWarning =
+        "Failed to find expected binary shader data in 'Particles/Standard Unlit2'.";
+
+    private const string CustomCreatureWarning =
+        "Failed to find expected binary shader data in 'Custom/Creature'.";
+
+    private static MethodBase TargetMethod()
+    {
+        return AccessTools.Method(typeof(BepInEx.Logging.Logger), "InternalLogEvent");
+    }
+
+    private static bool Prefix(LogEventArgs eventArgs)
+    {
+        if ((eventArgs.Level & LogLevel.Warning) == 0)
+        {
+            return true;
+        }
+
+        string message = eventArgs.Data?.ToString() ?? string.Empty;
+        return message != ParticlesStandardUnlitWarning && message != CustomCreatureWarning;
+    }
+}

--- a/More World Locations_AIO/Src/Traders/TraderItems.cs
+++ b/More World Locations_AIO/Src/Traders/TraderItems.cs
@@ -8,42 +8,21 @@ namespace More_World_Locations_AIO.Traders;
 
 public class TraderItems
 {
+    private const string BlacksmithStoneBasePrefab = "Ruby";
+    private const string SkillBookBasePrefab = "CryptKey";
+
     public static ItemDrop.ItemData blacksmithStoneItemData_tier1;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier2;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier3;
 
     public static void CreateCustomItems()
     {
-        var assetBundle = Prefabs.vendorsPrefabBundle;
-        
-        // Tier 1
-        ItemConfig blacksmithStoneItemConfig_tier1 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier1 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier1", fixReference: false, blacksmithStoneItemConfig_tier1);
-        ItemDrop blacksmithStoneItemDrop_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop;
-        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier1 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier1.stoneTier = 1;
-        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier1;
+        CustomItem blacksmithStoneCustomItem_tier1 = CreateBlacksmithStone("MWL_blacksmithStone_tier1", 1);
+        CustomItem blacksmithStoneCustomItem_tier2 = CreateBlacksmithStone("MWL_blacksmithStone_tier2", 2);
+        CustomItem blacksmithStoneCustomItem_tier3 = CreateBlacksmithStone("MWL_blacksmithStone_tier3", 3);
+
         blacksmithStoneItemData_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop.m_itemData;
-        
-        // Tier 2
-        ItemConfig blacksmithStoneItemConfig_tier2 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier2 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier2", fixReference: false, blacksmithStoneItemConfig_tier2);
-        ItemDrop blacksmithStoneItemDrop_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop;
-        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier2 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier2.stoneTier = 2;
-        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier2;
         blacksmithStoneItemData_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop.m_itemData;
-        
-        // Tier 3
-        ItemConfig blacksmithStoneItemConfig_tier3 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier3 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier3", fixReference: false, blacksmithStoneItemConfig_tier3);
-        ItemDrop blacksmithStoneItemDrop_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop;
-        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier3 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier3.stoneTier = 3;
-        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier3;
         blacksmithStoneItemData_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop.m_itemData;
         
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier1);
@@ -53,14 +32,29 @@ public class TraderItems
         // Skill Books
         BuildSkillBooks();
     }
+
+    private static CustomItem CreateBlacksmithStone(string prefabName, int tier)
+    {
+        ItemConfig itemConfig = new ItemConfig
+        {
+            Name = $"$item_mwl_blacksmithstone_tier{tier}",
+            Description = "$item_mwl_blacksmithstone_description",
+            StackSize = 10,
+        };
+
+        CustomItem customItem = new CustomItem(prefabName, BlacksmithStoneBasePrefab, itemConfig);
+        ItemDrop itemDrop = customItem.ItemDrop;
+        itemDrop.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
+
+        BlacksmithStone_SE blacksmithStoneEffect = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
+        blacksmithStoneEffect.stoneTier = tier;
+        itemDrop.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect;
+
+        return customItem;
+    }
     
     public static void BuildSkillBooks()
     {
-        var assetBundle = Prefabs.vendorsPrefabBundle;
-        
-        CustomPrefab skillBookPrefab = new CustomPrefab(assetBundle, "MWL_skillTome", fixReference: false);
-        PrefabManager.Instance.AddPrefab(skillBookPrefab);
-        
         foreach (Skills.SkillType skill in Enum.GetValues(typeof(Skills.SkillType)))
         {
             if (skill == Skills.SkillType.None || skill == Skills.SkillType.All) continue;
@@ -76,7 +70,7 @@ public class TraderItems
     {
         ItemConfig bookConfig = new ItemConfig();
         string customItemName = "MWL_skillBook_" + skill.ToString() + "_bookTier" + tier;
-        CustomItem customItem = new CustomItem(customItemName, "MWL_skillTome", bookConfig);
+        CustomItem customItem = new CustomItem(customItemName, SkillBookBasePrefab, bookConfig);
         ItemDrop itemDrop = customItem.ItemDrop;
         itemDrop.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
         itemDrop.m_itemData.m_shared.m_maxStackSize = 10;

--- a/More World Locations_AIO/Src/Traders/TraderItems.cs
+++ b/More World Locations_AIO/Src/Traders/TraderItems.cs
@@ -8,53 +8,59 @@ namespace More_World_Locations_AIO.Traders;
 
 public class TraderItems
 {
-    private const string BlacksmithStoneBasePrefab = "Ruby";
-    private const string SkillBookBasePrefab = "CryptKey";
-
     public static ItemDrop.ItemData blacksmithStoneItemData_tier1;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier2;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier3;
 
     public static void CreateCustomItems()
     {
-        CustomItem blacksmithStoneCustomItem_tier1 = CreateBlacksmithStone("MWL_blacksmithStone_tier1", 1);
-        CustomItem blacksmithStoneCustomItem_tier2 = CreateBlacksmithStone("MWL_blacksmithStone_tier2", 2);
-        CustomItem blacksmithStoneCustomItem_tier3 = CreateBlacksmithStone("MWL_blacksmithStone_tier3", 3);
+        var assetBundle = Prefabs.vendorsPrefabBundle;
 
+        // Tier 1
+        ItemConfig blacksmithStoneItemConfig_tier1 = new ItemConfig();
+        CustomItem blacksmithStoneCustomItem_tier1 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier1", fixReference: false, blacksmithStoneItemConfig_tier1);
+        ItemDrop blacksmithStoneItemDrop_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop;
+        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
+        BlacksmithStone_SE blacksmithStoneEffect_tier1 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
+        blacksmithStoneEffect_tier1.stoneTier = 1;
+        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier1;
         blacksmithStoneItemData_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop.m_itemData;
+
+        // Tier 2
+        ItemConfig blacksmithStoneItemConfig_tier2 = new ItemConfig();
+        CustomItem blacksmithStoneCustomItem_tier2 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier2", fixReference: false, blacksmithStoneItemConfig_tier2);
+        ItemDrop blacksmithStoneItemDrop_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop;
+        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
+        BlacksmithStone_SE blacksmithStoneEffect_tier2 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
+        blacksmithStoneEffect_tier2.stoneTier = 2;
+        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier2;
         blacksmithStoneItemData_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop.m_itemData;
+
+        // Tier 3
+        ItemConfig blacksmithStoneItemConfig_tier3 = new ItemConfig();
+        CustomItem blacksmithStoneCustomItem_tier3 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier3", fixReference: false, blacksmithStoneItemConfig_tier3);
+        ItemDrop blacksmithStoneItemDrop_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop;
+        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
+        BlacksmithStone_SE blacksmithStoneEffect_tier3 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
+        blacksmithStoneEffect_tier3.stoneTier = 3;
+        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier3;
         blacksmithStoneItemData_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop.m_itemData;
-        
+
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier1);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier2);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier3);
-        
+
         // Skill Books
         BuildSkillBooks();
     }
 
-    private static CustomItem CreateBlacksmithStone(string prefabName, int tier)
-    {
-        ItemConfig itemConfig = new ItemConfig
-        {
-            Name = $"$item_mwl_blacksmithstone_tier{tier}",
-            Description = "$item_mwl_blacksmithstone_description",
-            StackSize = 10,
-        };
-
-        CustomItem customItem = new CustomItem(prefabName, BlacksmithStoneBasePrefab, itemConfig);
-        ItemDrop itemDrop = customItem.ItemDrop;
-        itemDrop.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-
-        BlacksmithStone_SE blacksmithStoneEffect = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect.stoneTier = tier;
-        itemDrop.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect;
-
-        return customItem;
-    }
-    
     public static void BuildSkillBooks()
     {
+        var assetBundle = Prefabs.vendorsPrefabBundle;
+
+        CustomPrefab skillBookPrefab = new CustomPrefab(assetBundle, "MWL_skillTome", fixReference: false);
+        PrefabManager.Instance.AddPrefab(skillBookPrefab);
+
         foreach (Skills.SkillType skill in Enum.GetValues(typeof(Skills.SkillType)))
         {
             if (skill == Skills.SkillType.None || skill == Skills.SkillType.All) continue;
@@ -65,12 +71,12 @@ public class TraderItems
             }
         }
     }
-    
+
     public static void CreateSkillBook(Skills.SkillType skill, int tier)
     {
         ItemConfig bookConfig = new ItemConfig();
         string customItemName = "MWL_skillBook_" + skill.ToString() + "_bookTier" + tier;
-        CustomItem customItem = new CustomItem(customItemName, SkillBookBasePrefab, bookConfig);
+        CustomItem customItem = new CustomItem(customItemName, "MWL_skillTome", bookConfig);
         ItemDrop itemDrop = customItem.ItemDrop;
         itemDrop.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
         itemDrop.m_itemData.m_shared.m_maxStackSize = 10;
@@ -82,7 +88,7 @@ public class TraderItems
         skillBook_SE.skillType = skill;
         skillBook_SE.bookTier = tier;
         itemDrop.m_itemData.m_shared.m_consumeStatusEffect = skillBook_SE;
-        
+
         ItemManager.Instance.AddItem(customItem);
     }
 }


### PR DESCRIPTION
## Summary
- Fixes WARP-44 / https://linear.app/warpalicious/issue/WARP-44/investigate-mwl-501-log-spam-after-removing-underground-ruins
- Removes invalid `8_PuzzleStand` expectation from the Underground Ruins pack; the pack defines exactly `0_PuzzleStand` through `7_PuzzleStand`.
- Registers `BFD_Modular12_Solution_Light` as a clone of the existing `BFD_Modular8_Puzzle_Light` prefab so Jotunn mock resolution has a target without requiring a nonexistent bundled asset.
- Filters the two exact legacy Unity shader warning messages emitted while MWL loads retained Underground Ruins assets: `Particles/Standard Unlit2` and `Custom/Creature`.

## Investigation
- Read WARP-44, issue comments, QA failure notes, retained QA logs, and the Discord source context.
- No affected world copy was present under `/home/warp/Develop`, so live migration reproduction on the reporter world was not possible in the implementation session.
- Code inspection reproduced the `8_PuzzleStand` registrar warning directly: the expected list included `8_PuzzleStand`, but registration only creates eight stands, numbered 0 through 7.
- QA confirmed the prefab/mock portion was fixed but client launch still produced 608 binary shader warnings in the Season 6 stack.
- The remaining shader messages are Unity warnings from legacy bundled shader metadata during asset loading; they are not actionable from C# prefab registration without rebuilding the source asset bundles, so the final change filters only those two exact warning strings.

## Validation
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Debug` passed with existing warnings and 0 errors.
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Release` passed with existing warnings and 0 errors.
- Deployed Release DLL `e0cc3e5ef53a0e4a36a2d64087b6a2a04e5fa8890de8e4dd6a7e86009047be7f` to Valdev and valnet-client-02 `praetoris-season-6` profiles.
- Started Valdev, launched valnet-client-02, joined the server, reached in-world state, and ran `gotolocation BFD_Exterior`.
- Fresh client log counts after the final commit: 0 `Failed to find expected binary shader data`, 0 `Particles/Standard Unlit2`, 0 `Custom/Creature`, 0 `8_PuzzleStand`, 0 `could not be resolved`.
- OBS proof captured at `/home/warp/agents/odin/qa-evidence/WARP-44/WARP-44-BFD-Exterior-cf40932.png`; client log at `/home/warp/agents/odin/qa-evidence/WARP-44/mmcli-warp44-launch-cf40932.log`.

## Notes
- Unknown prefab ZDO warnings after removing the standalone Underground Ruins mod remain expected cleanup fallout; users should run the supported Upgrade World cleanup flow on an affected-world copy.