### PR TITLE
WARP-45 Prevent Blacksmith Stone loss without upgrade

### DIFF
--- a/More World Locations_AIO/Src/Traders/BlacksmithStone_SE.cs
+++ b/More World Locations_AIO/Src/Traders/BlacksmithStone_SE.cs
@@ -1,3 +1,4 @@
+using HarmonyLib;
 using UnityEngine;
 
 namespace More_World_Locations_AIO.Traders;
@@ -5,8 +6,7 @@ namespace More_World_Locations_AIO.Traders;
 public class BlacksmithStone_SE : StatusEffect
 {
     private bool shouldRemove = false;
-    private int m_qualityIncreaseAmount = 1;
-    private Player player;
+    private Player? player;
     public int stoneTier = 1;
     
     public override void Setup(Character character)
@@ -23,9 +23,9 @@ public class BlacksmithStone_SE : StatusEffect
             Inventory inventory = player.GetInventory();
             ItemDrop.ItemData item = inventory.GetItemAt(0, 0);
 
-            if (CheckItem(item) && isQualityCompatible(item, stoneTier))
+            if (CanEnhanceItem(item, stoneTier))
             {
-                item.m_quality += (int)m_qualityIncreaseAmount;
+                item.m_quality += 1;
                 player.Message(MessageHud.MessageType.Center, "Item: " + item.m_shared.m_name + " was enhanced");
                 return true;
             }
@@ -39,7 +39,7 @@ public class BlacksmithStone_SE : StatusEffect
         return false;
     }
     
-    public bool CheckItem(ItemDrop.ItemData item)
+    public static bool CheckItem(ItemDrop.ItemData item)
     {
         if (item == null || item.m_shared == null || item.m_shared.m_itemType == ItemDrop.ItemData.ItemType.None)
         {
@@ -65,9 +65,38 @@ public class BlacksmithStone_SE : StatusEffect
         }
     }
 
-    public bool isQualityCompatible(ItemDrop.ItemData item, int stoneTier)
+    public static bool isQualityCompatible(ItemDrop.ItemData item, int stoneTier)
     {
         return item.m_quality == item.m_shared.m_maxQuality + (stoneTier - 1);
+    }
+
+    public static bool CanEnhanceTopLeftItem(Player player, int stoneTier)
+    {
+        if (player == null)
+        {
+            return false;
+        }
+
+        Inventory inventory = player.GetInventory();
+        return CanEnhanceItem(inventory.GetItemAt(0, 0), stoneTier);
+    }
+
+    public static bool CanEnhanceItem(ItemDrop.ItemData item, int stoneTier)
+    {
+        return CheckItem(item) && isQualityCompatible(item, stoneTier);
+    }
+
+    public static bool TryGetBlacksmithStone(ItemDrop.ItemData item, out BlacksmithStone_SE blacksmithStone)
+    {
+        BlacksmithStone_SE? matchedStone = item?.m_shared?.m_consumeStatusEffect as BlacksmithStone_SE;
+        if (matchedStone == null)
+        {
+            blacksmithStone = null!;
+            return false;
+        }
+
+        blacksmithStone = matchedStone;
+        return true;
     }
     
     public override void UpdateStatusEffect(float dt)
@@ -80,8 +109,14 @@ public class BlacksmithStone_SE : StatusEffect
         }
         else
         {
+            if (player == null)
+            {
+                shouldRemove = true;
+                return;
+            }
+
             Inventory inventory = player.GetInventory();
-            inventory.AddItem(GetBlacksmithStoneItemData(), inventory.FindEmptySlot(true));
+            inventory.AddItem(GetBlacksmithStoneItemData().Clone());
             shouldRemove = true;
         }
     }
@@ -104,5 +139,26 @@ public class BlacksmithStone_SE : StatusEffect
     public override bool IsDone()
     {
         return shouldRemove || base.IsDone();
+    }
+}
+
+[HarmonyPatch(typeof(Player), nameof(Player.CanConsumeItem))]
+public static class BlacksmithStoneCanConsumeItemPatch
+{
+    private static bool Prefix(Player __instance, ItemDrop.ItemData item, ref bool __result)
+    {
+        if (!BlacksmithStone_SE.TryGetBlacksmithStone(item, out BlacksmithStone_SE blacksmithStone))
+        {
+            return true;
+        }
+
+        if (BlacksmithStone_SE.CanEnhanceTopLeftItem(__instance, blacksmithStone.stoneTier))
+        {
+            return true;
+        }
+
+        __instance.Message(MessageHud.MessageType.Center, "No suitable item found in top left corner of inventory.");
+        __result = false;
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- Adds a targeted `Player.CanConsumeItem` guard for MWL Blacksmith Stones so they cannot be consumed unless the top-left inventory item is a compatible upgrade target.
- Reuses the same compatibility check for the status effect upgrade path.
- Clones the fallback returned stone item data instead of reusing the registered shared item data.

## Reproduction / Inspection
- Static reproduction path confirmed: Valheim removes consumables after `CanConsumeItem`; the old code consumed the stone first and only returned a replacement later when no upgrade occurred. Rapid repeated use could consume additional stones while the existing Blacksmith Stone status effect was still active, so no new return effect would run for those consumed stones.
- Live Valheim integration validation was not run because WARP-45 instructions for this coding session limited checks to build and fast automated checks.

## Validation
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj"` passes with 152 existing warnings and 0 errors.

Linear: WARP-45

Mac resume command: `codex-sync WARP-45 nexus-1`