### PR TITLE
WARP-52 Skip invalid Draugr pile ZDO loads

### DIFF
--- a/More World Locations_AIO/Src/Dungeons/DraugrPileSpawnerZdoPatch.cs
+++ b/More World Locations_AIO/Src/Dungeons/DraugrPileSpawnerZdoPatch.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace More_World_Locations_AIO.Dungeons;
+
+internal static class DraugrPileSpawnerZdoPatch
+{
+    private const string PrefabName = "Spawner_DraugrPile";
+
+    internal static bool SkipPersistedDraugrPileSpawnerZDO(ZDO zdo, ref GameObject? __result)
+    {
+        if (zdo.GetPrefab() != PrefabName.GetStableHashCode())
+        {
+            return true;
+        }
+
+        __result = null;
+        Debug.Log($"DraugrPileSpawnerZdoPatch: skipped persisted '{PrefabName}' ZDO {zdo.m_uid}");
+        return false;
+    }
+}

--- a/More World Locations_AIO/Src/Dungeons/Packs/ForbiddenCatacombsPack.cs
+++ b/More World Locations_AIO/Src/Dungeons/Packs/ForbiddenCatacombsPack.cs
@@ -49,6 +49,12 @@ public static class ForbiddenCatacombsPack
             new CustomPrefabSpec { Name = KitPrefix + "altarHolder", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = KitPrefix + "AltarDoor",   Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = KitPrefix + "secretdoor",  Source = CustomPrefabSource.Bundled },
+            new CustomPrefabSpec
+            {
+                Name = KitPrefix + "Spawner_DraugrPile",
+                Source = CustomPrefabSource.VanillaClone,
+                VanillaSource = "Spawner_DraugrPile",
+            },
             new CustomPrefabSpec { Name = KitPrefix + "CryptKey",    Source = CustomPrefabSource.Bundled },
         },
 

--- a/More World Locations_AIO/Src/Dungeons/Packs/ForbiddenCatacombsPack.cs
+++ b/More World Locations_AIO/Src/Dungeons/Packs/ForbiddenCatacombsPack.cs
@@ -49,12 +49,6 @@ public static class ForbiddenCatacombsPack
             new CustomPrefabSpec { Name = KitPrefix + "altarHolder", Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = KitPrefix + "AltarDoor",   Source = CustomPrefabSource.Bundled },
             new CustomPrefabSpec { Name = KitPrefix + "secretdoor",  Source = CustomPrefabSource.Bundled },
-            new CustomPrefabSpec
-            {
-                Name = KitPrefix + "Spawner_DraugrPile",
-                Source = CustomPrefabSource.VanillaClone,
-                VanillaSource = "Spawner_DraugrPile",
-            },
             new CustomPrefabSpec { Name = KitPrefix + "CryptKey",    Source = CustomPrefabSource.Bundled },
         },
 

--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -77,6 +77,12 @@ namespace More_World_Locations_AIO
 
             Assembly assembly = Assembly.GetExecutingAssembly();
             _harmony.PatchAll(assembly);
+            _harmony.Patch(
+                AccessTools.DeclaredMethod(typeof(ZNetScene), "CreateObject"),
+                prefix: new HarmonyMethod(
+                    AccessTools.DeclaredMethod(
+                        typeof(DraugrPileSpawnerZdoPatch),
+                        nameof(DraugrPileSpawnerZdoPatch.SkipPersistedDraugrPileSpawnerZDO))));
             SetupWatcher();
 
             Prefabs.LoadPrefabBundles();


### PR DESCRIPTION
## Summary

- Skips creation of persisted `Spawner_DraugrPile` ZDOs before Valheim instantiates the non-networked prefab and logs `not used when creating object Spawner_DraugrPile`.
- Removes the earlier `CD_kit_Spawner_DraugrPile` clone registration because live validation showed saved objects still use the vanilla `Spawner_DraugrPile` prefab name.

## Cause

`CD_Exterior1` can persist `Spawner_DraugrPile` ZDOs. On reload, Valheim tries to recreate those ZDOs through `ZNetScene.CreateObject`, but the prefab does not consume `ZNetView.m_initZDO`, so Valheim logs `ZDO ... not used when creating object Spawner_DraugrPile` and the load can remain stuck on the generating screen.

## Validation

- Released 5.0.1 repro on `valnet-client-02` with a new `mmcli` profile containing MWL AIO, World Gen Accelerator, and dependencies: `CD_Exterior1` generated Draugr pile spawners, save/logout/reload reproduced `ZDO ... not used when creating object Spawner_DraugrPile` and the loading-screen failure.
- Deployed the fix DLL to the same Valnet profile, generated/loaded `Warp52CreateObjectFix`, went to a generated `CD_Exterior1`, confirmed `find Spawner_DraugrPile` found nearby spawners, saved/logged out/reloaded, and the player loaded back into the exterior area.
- Fixed-build log showed `DraugrPileSpawnerZdoPatch: skipped persisted ...` plus Valheim invalid-ZDO cleanup, with no `not used when creating object Spawner_DraugrPile` lines.
- Final post-refactor DLL hash deployed and loaded on Valnet: `28668235d8eb7c51eaea5fd6a91abba0c175ed8b67dc24812bc27b3f1ca0ae77`; exact grep for `not used when creating object Spawner_DraugrPile` was empty after loading the validation world.
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Release` passed with 154 existing warnings, 0 errors.

Linear: https://linear.app/warpalicious/issue/WARP-52/fix-mwl-aio-spawner-draugrpile-zdo-load-failures