### PR TITLE
chore: bump MWL AIO version to 5.0.2

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -24,7 +24,7 @@ namespace More_World_Locations_AIO
     public class More_World_Locations_AIOPlugin : BaseUnityPlugin
     {
         internal const string ModName = "More_World_Locations_AIO";
-        internal const string ModVersion = "5.0.1";
+        internal const string ModVersion = "5.0.2";
         internal const string Author = "warpalicious";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";


### PR DESCRIPTION
## Summary
- Bump More World Locations AIO plugin version to 5.0.2 for the Thunderstore release package.

## Validation
- Built `More World Locations_AIO/More World Locations_AIO.csproj` in Release mode successfully.
- Staged release DLL reports `More_World_Locations_AIO, Version=5.0.2.0`.
- Thunderstore 5.0.2 staging folder was updated separately with the fresh DLL, fixed `cd_lower_cell3` bundle, and updated changelog.