### PR TITLE
WARP-65 Remove Black Metal from Fine Shipment manifest

### DIFF
--- a/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
+++ b/More World Locations_AIO/Src/Ports/PortMain/PortInit.cs
@@ -180,7 +180,6 @@ public static class PortInit
             manifest.CostToShip = 100;
             manifest.Recipe.Add("FineWood", 10);
             manifest.Recipe.Add("Iron", 2);
-            manifest.Recipe.Add("BlackMetal", 6);
             manifest.Icon = icon;
             manifest.PlaceEffect = placeEffect;
         };


### PR DESCRIPTION
## Summary
- Removes the unintended Black Metal requirement from the Fine Shipment manifest recipe.
- Leaves adjacent shipment recipes unchanged, including Fuling Shipment requiring Black Metal.

## Validation
- Reproduced via shipped recipe source before coding: Fine Shipment had FineWood, Iron, and BlackMetal.
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj"` passed with existing warnings.
- Live Valnet validation on `valnet-client-01`: loaded the built MWL DLL in `praetoris-season-6` and used a temporary BepInEx reflection probe to log manifest requirements. Fine Shipment logged `$item_finewood:10,$item_iron:2`; Fuling Shipment logged `$item_finewood:10,$item_tar:2,$item_blackmetal:6`. Evidence saved at `/tmp/warp65-live-validation.log` on nexus-1.
- Cleanup: removed the temporary probe, restored the previous client profile MWL DLL, stopped Valheim, stopped `valnet-client-01`, and released the lease.

Linear: WARP-65
Mac resume: `codex-sync WARP-65 nexus-1`