### PR TITLE
Release MWL AIO 5.0.3

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -24,7 +24,7 @@ namespace More_World_Locations_AIO
     public class More_World_Locations_AIOPlugin : BaseUnityPlugin
     {
         internal const string ModName = "More_World_Locations_AIO";
-        internal const string ModVersion = "5.0.2";
+        internal const string ModVersion = "5.0.3";
         internal const string Author = "warpalicious";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";


### PR DESCRIPTION
## Summary
- Bumps More World Locations AIO source version to `5.0.3` for the WARP-65 release.
- Stages the Thunderstore package locally at `/Users/benjmarston/Develop/valheimModding/modRelease/MoreWorldLocations_All/5.0.3/`.
- Package zip is staged at `/Users/benjmarston/Develop/valheimModding/modRelease/MoreWorldLocations_All/5.0.3/MoreWorldLocations_All-5.0.3.zip`.

## Validation
- Merged WARP-65 fix PR #87 into `master`.
- Built `More World Locations_AIO/More World Locations_AIO.csproj` in Release: 0 errors, existing warnings remain.
- Verified staged `manifest.json` has `version_number` `5.0.3`.
- Verified built DLL reports assembly version `5.0.3.0`.
- Compared staged `5.0.3` package layout to `5.0.2`; no missing or extra package files apart from the new zip name.
- Verified zip has no `.DS_Store` and does not contain itself.

## Release Notes
- Fixed the Fine Shipment manifest recipe requiring Black Metal Bars.
