### PR TITLE
[codex] Add tier 4 blacksmith stone upgrade

### DIFF
--- a/More World Locations_AIO/Src/Traders/BlacksmithStone_SE.cs
+++ b/More World Locations_AIO/Src/Traders/BlacksmithStone_SE.cs
@@ -5,6 +5,7 @@ namespace More_World_Locations_AIO.Traders;
 
 public class BlacksmithStone_SE : StatusEffect
 {
+    private const int DirectUpgradeStoneTier = 4;
     private bool shouldRemove = false;
     private Player? player;
     public int stoneTier = 1;
@@ -25,7 +26,7 @@ public class BlacksmithStone_SE : StatusEffect
 
             if (CanEnhanceItem(item, stoneTier))
             {
-                item.m_quality += 1;
+                item.m_quality = GetEnhancedQuality(item, stoneTier);
                 player.Message(MessageHud.MessageType.Center, "Item: " + item.m_shared.m_name + " was enhanced");
                 return true;
             }
@@ -67,7 +68,13 @@ public class BlacksmithStone_SE : StatusEffect
 
     public static bool isQualityCompatible(ItemDrop.ItemData item, int stoneTier)
     {
-        return item.m_quality == item.m_shared.m_maxQuality + (stoneTier - 1);
+        int targetQuality = GetTargetQuality(item, stoneTier);
+        if (IsDirectUpgradeTier(stoneTier))
+        {
+            return item.m_quality < targetQuality;
+        }
+
+        return item.m_quality == targetQuality - 1;
     }
 
     public static bool CanEnhanceTopLeftItem(Player player, int stoneTier)
@@ -84,6 +91,26 @@ public class BlacksmithStone_SE : StatusEffect
     public static bool CanEnhanceItem(ItemDrop.ItemData item, int stoneTier)
     {
         return CheckItem(item) && isQualityCompatible(item, stoneTier);
+    }
+
+    private static bool IsDirectUpgradeTier(int stoneTier)
+    {
+        return stoneTier == DirectUpgradeStoneTier;
+    }
+
+    private static int GetTargetQuality(ItemDrop.ItemData item, int stoneTier)
+    {
+        return item.m_shared.m_maxQuality + stoneTier;
+    }
+
+    private static int GetEnhancedQuality(ItemDrop.ItemData item, int stoneTier)
+    {
+        if (IsDirectUpgradeTier(stoneTier))
+        {
+            return GetTargetQuality(item, stoneTier);
+        }
+
+        return item.m_quality + 1;
     }
 
     public static bool TryGetBlacksmithStone(ItemDrop.ItemData item, out BlacksmithStone_SE blacksmithStone)
@@ -131,6 +158,8 @@ public class BlacksmithStone_SE : StatusEffect
                 return TraderItems.blacksmithStoneItemData_tier2;
             case 3:
                 return TraderItems.blacksmithStoneItemData_tier3;
+            case 4:
+                return TraderItems.blacksmithStoneItemData_tier4;
             default:
                 return TraderItems.blacksmithStoneItemData_tier1;
         }

--- a/More World Locations_AIO/Src/Traders/TraderItems.cs
+++ b/More World Locations_AIO/Src/Traders/TraderItems.cs
@@ -20,12 +20,11 @@ public class TraderItems
         CustomItem blacksmithStoneCustomItem_tier1 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier1", 1, out blacksmithStoneItemData_tier1);
         CustomItem blacksmithStoneCustomItem_tier2 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier2", 2, out blacksmithStoneItemData_tier2);
         CustomItem blacksmithStoneCustomItem_tier3 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier3", 3, out blacksmithStoneItemData_tier3);
+        CustomItem blacksmithStoneCustomItem_tier4 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier4", 4, out blacksmithStoneItemData_tier4);
         
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier1);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier2);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier3);
-
-        CustomItem blacksmithStoneCustomItem_tier4 = CreateClonedBlacksmithStone("MWL_blacksmithStone_tier4", "MWL_blacksmithStone_tier3", 4, "$item_mwl_blacksmithstone_tier4", out blacksmithStoneItemData_tier4);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier4);
         
         // Skill Books
@@ -38,18 +37,6 @@ public class TraderItems
         CustomItem customItem = new CustomItem(assetBundle, prefabName, fixReference: false, itemConfig);
         ConfigureBlacksmithStone(customItem.ItemDrop, stoneTier);
         itemData = customItem.ItemDrop.m_itemData;
-        return customItem;
-    }
-
-    private static CustomItem CreateClonedBlacksmithStone(string prefabName, string basePrefabName, int stoneTier, string localizationKey, out ItemDrop.ItemData itemData)
-    {
-        ItemConfig itemConfig = new ItemConfig();
-        CustomItem customItem = new CustomItem(prefabName, basePrefabName, itemConfig);
-        ItemDrop itemDrop = customItem.ItemDrop;
-        itemDrop.m_itemData.m_shared.m_name = localizationKey;
-        itemDrop.m_itemData.m_shared.m_description = "$item_mwl_blacksmithstone_description";
-        ConfigureBlacksmithStone(itemDrop, stoneTier);
-        itemData = itemDrop.m_itemData;
         return customItem;
     }
 

--- a/More World Locations_AIO/Src/Traders/TraderItems.cs
+++ b/More World Locations_AIO/Src/Traders/TraderItems.cs
@@ -11,47 +11,54 @@ public class TraderItems
     public static ItemDrop.ItemData blacksmithStoneItemData_tier1;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier2;
     public static ItemDrop.ItemData blacksmithStoneItemData_tier3;
+    public static ItemDrop.ItemData blacksmithStoneItemData_tier4;
 
     public static void CreateCustomItems()
     {
-        var assetBundle = Prefabs.vendorsPrefabBundle;
+        AssetBundle assetBundle = Prefabs.vendorsPrefabBundle;
         
-        // Tier 1
-        ItemConfig blacksmithStoneItemConfig_tier1 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier1 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier1", fixReference: false, blacksmithStoneItemConfig_tier1);
-        ItemDrop blacksmithStoneItemDrop_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop;
-        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier1 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier1.stoneTier = 1;
-        blacksmithStoneItemDrop_tier1.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier1;
-        blacksmithStoneItemData_tier1 = blacksmithStoneCustomItem_tier1.ItemDrop.m_itemData;
-        
-        // Tier 2
-        ItemConfig blacksmithStoneItemConfig_tier2 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier2 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier2", fixReference: false, blacksmithStoneItemConfig_tier2);
-        ItemDrop blacksmithStoneItemDrop_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop;
-        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier2 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier2.stoneTier = 2;
-        blacksmithStoneItemDrop_tier2.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier2;
-        blacksmithStoneItemData_tier2 = blacksmithStoneCustomItem_tier2.ItemDrop.m_itemData;
-        
-        // Tier 3
-        ItemConfig blacksmithStoneItemConfig_tier3 = new ItemConfig();
-        CustomItem blacksmithStoneCustomItem_tier3 = new CustomItem(assetBundle, "MWL_blacksmithStone_tier3", fixReference: false, blacksmithStoneItemConfig_tier3);
-        ItemDrop blacksmithStoneItemDrop_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop;
-        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
-        BlacksmithStone_SE blacksmithStoneEffect_tier3 = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
-        blacksmithStoneEffect_tier3.stoneTier = 3;
-        blacksmithStoneItemDrop_tier3.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect_tier3;
-        blacksmithStoneItemData_tier3 = blacksmithStoneCustomItem_tier3.ItemDrop.m_itemData;
+        CustomItem blacksmithStoneCustomItem_tier1 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier1", 1, out blacksmithStoneItemData_tier1);
+        CustomItem blacksmithStoneCustomItem_tier2 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier2", 2, out blacksmithStoneItemData_tier2);
+        CustomItem blacksmithStoneCustomItem_tier3 = CreateBundledBlacksmithStone(assetBundle, "MWL_blacksmithStone_tier3", 3, out blacksmithStoneItemData_tier3);
         
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier1);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier2);
         ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier3);
+
+        CustomItem blacksmithStoneCustomItem_tier4 = CreateClonedBlacksmithStone("MWL_blacksmithStone_tier4", "MWL_blacksmithStone_tier3", 4, "$item_mwl_blacksmithstone_tier4", out blacksmithStoneItemData_tier4);
+        ItemManager.Instance.AddItem(blacksmithStoneCustomItem_tier4);
         
         // Skill Books
         BuildSkillBooks();
+    }
+
+    private static CustomItem CreateBundledBlacksmithStone(AssetBundle assetBundle, string prefabName, int stoneTier, out ItemDrop.ItemData itemData)
+    {
+        ItemConfig itemConfig = new ItemConfig();
+        CustomItem customItem = new CustomItem(assetBundle, prefabName, fixReference: false, itemConfig);
+        ConfigureBlacksmithStone(customItem.ItemDrop, stoneTier);
+        itemData = customItem.ItemDrop.m_itemData;
+        return customItem;
+    }
+
+    private static CustomItem CreateClonedBlacksmithStone(string prefabName, string basePrefabName, int stoneTier, string localizationKey, out ItemDrop.ItemData itemData)
+    {
+        ItemConfig itemConfig = new ItemConfig();
+        CustomItem customItem = new CustomItem(prefabName, basePrefabName, itemConfig);
+        ItemDrop itemDrop = customItem.ItemDrop;
+        itemDrop.m_itemData.m_shared.m_name = localizationKey;
+        itemDrop.m_itemData.m_shared.m_description = "$item_mwl_blacksmithstone_description";
+        ConfigureBlacksmithStone(itemDrop, stoneTier);
+        itemData = itemDrop.m_itemData;
+        return customItem;
+    }
+
+    private static void ConfigureBlacksmithStone(ItemDrop itemDrop, int stoneTier)
+    {
+        itemDrop.m_itemData.m_shared.m_itemType = ItemDrop.ItemData.ItemType.Consumable;
+        BlacksmithStone_SE blacksmithStoneEffect = ScriptableObject.CreateInstance<BlacksmithStone_SE>();
+        blacksmithStoneEffect.stoneTier = stoneTier;
+        itemDrop.m_itemData.m_shared.m_consumeStatusEffect = blacksmithStoneEffect;
     }
     
     public static void BuildSkillBooks()

--- a/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
+++ b/More World Locations_AIO/YAML/warpalicious.More_World_Locations_Localization.yml
@@ -17,6 +17,7 @@ se_skillBook: Skill Book
 item_mwl_blacksmithstone_tier1: Blacksmith Stone (1)
 item_mwl_blacksmithstone_tier2: Blacksmith Stone (2)
 item_mwl_blacksmithstone_tier3: Blacksmith Stone (3)
+item_mwl_blacksmithstone_tier4: Blacksmith Stone (4)
 item_mwl_blacksmithstone_description: "Upgrades an armor or weapon past max quality. Place an armor or weapon in top left cell in inventory and consume this item."
 
 # Skill Books (suffix tokens — skill name resolved from game's own $skill_* token)


### PR DESCRIPTION
## Summary
- add a tier 4 blacksmith stone status-effect path that upgrades eligible items directly to the tier 4 target quality
- keep tiers 1-3 on the existing exact one-level upgrade behavior
- add the tier 4 blacksmith stone prefab and supplied tier 4 sprite to the `moreworldvendors` bundle
- register tier 4 from the bundled prefab instead of cloning tier 3 at runtime

## Validation
- Unity CLI inspected the active Unity setup and verified existing blacksmith stone assets
- Unity 2022 batch build from the matching `valheimRipMocked` vendor-bundle layout rebuilt `moreworldvendors`
- Unity bundle load check: `16 assets; has tier4=True`
- Unity prefab load check: `prefab=MWL_blacksmithStone_tier4; itemName=$item_mwl_blacksmithstone_tier4; icons=1; icon=blacksmithStoneSprite_tier4`
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Debug`
- `dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Release`

Note: this repo uses `master` as its default branch; there is no `main` branch.