### PR TITLE
Bump MWL AIO to 5.0.4

### DIFF
--- a/More World Locations_AIO/Src/MoreWorldLocations.cs
+++ b/More World Locations_AIO/Src/MoreWorldLocations.cs
@@ -24,7 +24,7 @@ namespace More_World_Locations_AIO
     public class More_World_Locations_AIOPlugin : BaseUnityPlugin
     {
         internal const string ModName = "More_World_Locations_AIO";
-        internal const string ModVersion = "5.0.3";
+        internal const string ModVersion = "5.0.4";
         internal const string Author = "warpalicious";
         private const string ModGUID = Author + "." + ModName;
         private static string ConfigFileName = ModGUID + ".cfg";


### PR DESCRIPTION
Bumps More World Locations AIO plugin version to 5.0.4 for the minimap icon release.