### PR TITLE
Update MWL 5.0.6 release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![More World Locations AIO](https://i.imgur.com/Xd52Zfj.png)
 
 # More World Locations
-This mod massively enhances the world exploration component of Valheim by adding 180 new POI locations across all biomes, including 178 custom locations and 2 procedurally generated dungeons.
+This mod massively enhances the world exploration component of Valheim by adding 181 new POI locations across all biomes, including 179 custom locations and 2 procedurally generated dungeons.
 
 ## Table of Contents
 - [Features](#features)
@@ -30,7 +30,7 @@ This mod massively enhances the world exploration component of Valheim by adding
 - [Credit & Thanks](#credit--thanks)
 
 ## Features
-- Adds 178 custom locations across all biomes. Each spawns up to 20 times.
+- Adds 179 custom locations across all biomes. Each spawns up to 20 times.
 - Adds 2 procedurally generated dungeons, one in Black Forest and one in Swamp.
 - Adds Shipping Port locations to ship items and teleport between other discovered shipping port locations.
 - Adds Shrines that provide temporary buffs with randomized effects and durations.
@@ -57,7 +57,7 @@ This mod massively enhances the world exploration component of Valheim by adding
 
 </details>
 <details>
-  <summary>Adds 30 locations to the Swamp.</summary>
+  <summary>Adds 31 locations to the Swamp.</summary>
 
   ![Swamp Pack 1](https://i.imgur.com/l62Do90.png)
 
@@ -88,7 +88,7 @@ This mod massively enhances the world exploration component of Valheim by adding
 </details>
 
 ## Shipping Ports
-Shipping Ports are special coastal locations that introduce an item logistics system to Valheim. Four port locations spawn along coastlines in the Meadows, Blackforest, Plains, and Mistlands biomes, with each port spawning up to 5 times in a world.
+Shipping Ports are special coastal locations that introduce an item logistics system to Valheim. Six port locations spawn along coastlines in the Meadows, Blackforest, Swamp, Plains, Mistlands, and Ashlands biomes.
 
 **Discovering Ports:** Each port is staffed by an NPC dockmaster. You must interact with the NPC to discover the port and add it to your network. Only discovered ports can be used as shipping destinations.
 
@@ -438,7 +438,7 @@ A special thank you to the mod developer Rusty. He built the majority of the shi
 | MWL_Port3 | Hilli |
 | MWL_Port4 | iNavite |
 | MWL_Port5 | |
-| MWL_Port6 | |
+| MWL_Port6 | GizmoBuilder |
 | MWL_DvergrHouseWood1 | Hilli |
 | MWL_DvergrHouseWood2 | Hilli |
 | MWL_MarbleJail1 | Bryn |

--- a/README_thunderstore.md
+++ b/README_thunderstore.md
@@ -1,10 +1,10 @@
 ![More World Locations AIO](https://i.imgur.com/Xd52Zfj.png)
 
 # More World Locations
-This mod massively enhances the world exploration component of Valheim by adding 180 new POI locations across all biomes, including 178 custom locations and 2 procedurally generated dungeons.
+This mod massively enhances the world exploration component of Valheim by adding 181 new POI locations across all biomes, including 179 custom locations and 2 procedurally generated dungeons.
 
 ## Features
-- Adds 178 custom locations across all biomes. Each spawns up to 20 times.
+- Adds 179 custom locations across all biomes. Each spawns up to 20 times.
 - Adds 2 procedurally generated dungeons, one in Black Forest and one in Swamp.
 - Adds Shipping Port locations to ship items and teleport between other discovered shipping port locations.
 - Adds Shrines that provide temporary buffs with randomized effects and durations.
@@ -31,7 +31,7 @@ This mod massively enhances the world exploration component of Valheim by adding
 
 </details>
 <details>
-  <summary>Adds 30 locations to the Swamp.</summary>
+  <summary>Adds 31 locations to the Swamp.</summary>
 
   ![Swamp Pack 1](https://i.imgur.com/l62Do90.png)
 
@@ -62,7 +62,7 @@ This mod massively enhances the world exploration component of Valheim by adding
 </details>
 
 ## Shipping Ports
-Shipping Ports are special coastal locations that introduce an item logistics system to Valheim. Four port locations spawn along coastlines in the Meadows, Blackforest, Plains, and Mistlands biomes, with each port spawning up to 5 times in a world.
+Shipping Ports are special coastal locations that introduce an item logistics system to Valheim. Six port locations spawn along coastlines in the Meadows, Blackforest, Swamp, Plains, Mistlands, and Ashlands biomes.
 
 **Discovering Ports:** Each port is staffed by an NPC dockmaster. You must interact with the NPC to discover the port and add it to your network. Only discovered ports can be used as shipping destinations.
 
@@ -414,7 +414,7 @@ A special thank you to the mod developer Rusty. He built the majority of the shi
 | MWL_Port3 | Hilli |
 | MWL_Port4 | iNavite |
 | MWL_Port5 | |
-| MWL_Port6 | |
+| MWL_Port6 | GizmoBuilder |
 | MWL_DvergrHouseWood1 | Hilli |
 | MWL_DvergrHouseWood2 | Hilli |
 | MWL_MarbleJail1 | Bryn |

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -5,7 +5,7 @@ schemaVersion = "0.0.1"
 namespace = "warpalicious"
 name = "More_World_Locations_AIO"
 versionNumber = "5.0.6"
-description = "Adds 180 new POI locations including dungeons, traders, ports and much more to enhance Valheim's world exploration."
+description = "Adds 181 new POI locations including dungeons, traders, ports and much more to enhance Valheim's world exploration."
 websiteUrl = "https://discord.gg/3aaru2VyHJ"
 containsNsfwContent = false
 


### PR DESCRIPTION
## Summary

- Updates the MWL AIO location counts from 180/178 to 181/179 for the new swamp port.
- Updates the shipping ports copy to include all six port biomes.
- Credits `MWL_Port6` to `GizmoBuilder`.
- Updates the Thunderstore package description count to 181.

## Validation

- Metadata-only change; checked source and staged release metadata for stale 180/178 counts and blank Port6 credit.
