### PR TITLE
Fix protected MWL location piece health

### DIFF
--- a/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
+++ b/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using More_World_Locations_AIO.Managers;
+using More_World_Locations_AIO.Traders;
 using UnityEngine;
 
 namespace More_World_Locations_AIO;
@@ -20,9 +21,8 @@ public static class ProtectedLocationWearNTearPatch
         .Select(location => Helpers.GetNormalizedName(location.Name))
         .ToHashSet();
 
-    private static readonly string[] ProtectedAnchorPrefabs = LocationDefinitions.Traders
-        .Select(location => location.Name + "_Vendor")
-        .Concat(LocationDefinitions.Trainers.Select(location => location.Name + "_Trainer"))
+    private static readonly string[] ProtectedAnchorPrefabs = TraderPrefabs.TraderPrefabNames
+        .Concat(TraderPrefabs.TrainerPrefabNames)
         .ToArray();
 
     private static readonly List<ZDO> AnchorZdos = new();

--- a/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
+++ b/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
@@ -1,19 +1,18 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using More_World_Locations_AIO.Managers;
-using More_World_Locations_AIO.Traders;
 using UnityEngine;
 
 namespace More_World_Locations_AIO;
 
-[HarmonyPatch(typeof(Location), nameof(Location.Awake))]
 public static class ProtectedLocationWearNTearPatch
 {
     private const float ProtectedPieceHealth = 9999f;
     private const float MinimumProtectedRadius = 96f;
+    private static int protectedLocationSpawnDepth;
+    private static int protectedLocationBoundsFrame = -1;
 
     private static readonly HashSet<string> ProtectedLocations = LocationDefinitions.Ports
         .Concat(LocationDefinitions.Traders)
@@ -21,29 +20,33 @@ public static class ProtectedLocationWearNTearPatch
         .Select(location => Helpers.GetNormalizedName(location.Name))
         .ToHashSet();
 
-    private static readonly string[] ProtectedAnchorPrefabs = TraderPrefabs.TraderPrefabNames
-        .Concat(TraderPrefabs.TrainerPrefabNames)
-        .ToArray();
-
-    private static readonly List<ZDO> AnchorZdos = new();
-    private static readonly List<Vector3> ProtectedAnchorPositions = new();
-    private static int protectedAnchorPositionsFrame = -1;
-
-    [UsedImplicitly]
-    private static void Postfix(Location __instance)
+    private static readonly HashSet<string> ProtectedLocationGroups = new()
     {
-        if (__instance == null) return;
+        "MWL_Ports",
+        "MWL_Trader"
+    };
 
-        string locationName = Helpers.GetNormalizedName(__instance.name);
-        if (!ProtectedLocations.Contains(locationName)) return;
+    private static readonly List<ProtectedLocationBounds> ProtectedLocationBoundsCache = new();
 
-        foreach (WearNTear wearNTear in __instance.GetComponentsInChildren<WearNTear>(true))
+    internal static bool IsSpawningProtectedLocation => protectedLocationSpawnDepth > 0;
+
+    internal static bool EnterProtectedLocationSpawn(ZoneSystem.ZoneLocation location)
+    {
+        if (!IsProtectedLocationName(location))
         {
-            SetProtectedPieceHealthOnce(wearNTear);
+            return false;
         }
+
+        protectedLocationSpawnDepth++;
+        return true;
     }
 
-    internal static void SetProtectedPieceHealthOnce(WearNTear wearNTear)
+    internal static void ExitProtectedLocationSpawn()
+    {
+        protectedLocationSpawnDepth = Mathf.Max(0, protectedLocationSpawnDepth - 1);
+    }
+
+    internal static void SetProtectedPieceHealth(WearNTear wearNTear)
     {
         if (wearNTear == null) return;
 
@@ -78,65 +81,86 @@ public static class ProtectedLocationWearNTearPatch
         ZoneSystem zoneSystem = ZoneSystem.instance;
         if (zoneSystem == null) return false;
 
+        RefreshProtectedLocationBounds(zoneSystem);
+
         Vector3 position = wearNTear.transform.position;
+        foreach (ProtectedLocationBounds locationBounds in ProtectedLocationBoundsCache)
+        {
+            if (global::Utils.DistanceXZ(position, locationBounds.Position) <= locationBounds.Radius) return true;
+        }
+
+        return false;
+    }
+
+    private static void RefreshProtectedLocationBounds(ZoneSystem zoneSystem)
+    {
+        if (protectedLocationBoundsFrame == Time.frameCount)
+        {
+            return;
+        }
+
+        protectedLocationBoundsFrame = Time.frameCount;
+        ProtectedLocationBoundsCache.Clear();
+
         foreach (ZoneSystem.LocationInstance locationInstance in zoneSystem.GetLocationList())
         {
             if (!IsProtectedLocationName(locationInstance.m_location)) continue;
 
-            float radius = Mathf.Max(locationInstance.m_location.m_exteriorRadius, locationInstance.m_location.m_interiorRadius);
-            radius = Mathf.Max(radius, MinimumProtectedRadius);
-            if (global::Utils.DistanceXZ(position, locationInstance.m_position) <= radius) return true;
+            ProtectedLocationBoundsCache.Add(new ProtectedLocationBounds
+            {
+                Position = locationInstance.m_position,
+                Radius = GetProtectedLocationRadius(locationInstance.m_location)
+            });
         }
+    }
 
-        return false;
+    private static float GetProtectedLocationRadius(ZoneSystem.ZoneLocation location)
+    {
+        float radius = Mathf.Max(location.m_exteriorRadius, location.m_interiorRadius);
+        return Mathf.Max(radius, MinimumProtectedRadius);
     }
 
     private static bool IsProtectedLocationName(ZoneSystem.ZoneLocation location)
     {
-        if (ProtectedLocations.Contains(Helpers.GetNormalizedName(location.m_name))) return true;
-        if (ProtectedLocations.Contains(Helpers.GetNormalizedName(location.m_prefabName))) return true;
+        if (location == null) return false;
+        if (IsProtectedLocationName(location.m_name)) return true;
+        if (IsProtectedLocationName(location.m_prefabName)) return true;
+        if (ProtectedLocationGroups.Contains(location.m_group)) return true;
 
-        string prefabName = location.m_prefab.Name;
-        return !string.IsNullOrEmpty(prefabName) && ProtectedLocations.Contains(Helpers.GetNormalizedName(prefabName));
+        return location.m_prefab != null && IsProtectedLocationName(location.m_prefab.Name);
     }
 
-    internal static bool IsNearProtectedAnchor(Vector3 position)
+    private static bool IsProtectedLocationName(string locationName)
     {
-        if (ZDOMan.instance == null) return false;
-
-        RefreshProtectedAnchorPositions();
-        foreach (Vector3 anchorPosition in ProtectedAnchorPositions)
-        {
-            if (global::Utils.DistanceXZ(position, anchorPosition) <= MinimumProtectedRadius) return true;
-        }
-
-        return false;
+        return !string.IsNullOrEmpty(locationName) &&
+               ProtectedLocations.Contains(Helpers.GetNormalizedName(locationName));
     }
 
-    private static void RefreshProtectedAnchorPositions()
+    private struct ProtectedLocationBounds
     {
-        if (protectedAnchorPositionsFrame == Time.frameCount) return;
+        public Vector3 Position;
+        public float Radius;
+    }
+}
 
-        protectedAnchorPositionsFrame = Time.frameCount;
-        ProtectedAnchorPositions.Clear();
-        foreach (ZDO port in ShipmentManager.GetPorts())
+[HarmonyPatch(typeof(ZoneSystem), "SpawnLocation")]
+public static class ProtectedLocationSpawnPatch
+{
+    [UsedImplicitly]
+    private static void Prefix(ZoneSystem.ZoneLocation location, out bool __state)
+    {
+        __state = ProtectedLocationWearNTearPatch.EnterProtectedLocationSpawn(location);
+    }
+
+    [UsedImplicitly]
+    private static void Finalizer(bool __state)
+    {
+        if (!__state)
         {
-            ProtectedAnchorPositions.Add(port.GetPosition());
+            return;
         }
 
-        foreach (string anchorPrefab in ProtectedAnchorPrefabs)
-        {
-            AnchorZdos.Clear();
-            int index = 0;
-            while (!ZDOMan.instance.GetAllZDOsWithPrefabIterative(anchorPrefab, AnchorZdos, ref index))
-            {
-            }
-
-            foreach (ZDO anchor in AnchorZdos)
-            {
-                ProtectedAnchorPositions.Add(anchor.GetPosition());
-            }
-        }
+        ProtectedLocationWearNTearPatch.ExitProtectedLocationSpawn();
     }
 }
 
@@ -146,25 +170,12 @@ public static class ProtectedLocationWearNTearAwakePatch
     [UsedImplicitly]
     private static void Postfix(WearNTear __instance)
     {
-        __instance.StartCoroutine(SetProtectedHealthWhenAnchorsAreReady(__instance));
-    }
-
-    private static IEnumerator SetProtectedHealthWhenAnchorsAreReady(WearNTear wearNTear)
-    {
-        float[] delays = { 0f, 2f, 8f };
-        foreach (float delay in delays)
+        if (!ProtectedLocationWearNTearPatch.IsSpawningProtectedLocation &&
+            !ProtectedLocationWearNTearPatch.IsProtectedLocationPiece(__instance))
         {
-            if (delay > 0f) yield return new WaitForSeconds(delay);
-
-            if (wearNTear == null) yield break;
-            if (!ProtectedLocationWearNTearPatch.IsProtectedLocationPiece(wearNTear) &&
-                !ProtectedLocationWearNTearPatch.IsNearProtectedAnchor(wearNTear.transform.position))
-            {
-                continue;
-            }
-
-            ProtectedLocationWearNTearPatch.SetProtectedPieceHealthOnce(wearNTear);
-            yield break;
+            return;
         }
+
+        ProtectedLocationWearNTearPatch.SetProtectedPieceHealth(__instance);
     }
 }

--- a/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
+++ b/More World Locations_AIO/Src/Locations/ProtectedLocationWearNTearPatch.cs
@@ -1,8 +1,10 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
 using JetBrains.Annotations;
 using More_World_Locations_AIO.Managers;
+using UnityEngine;
 
 namespace More_World_Locations_AIO;
 
@@ -10,11 +12,22 @@ namespace More_World_Locations_AIO;
 public static class ProtectedLocationWearNTearPatch
 {
     private const float ProtectedPieceHealth = 9999f;
+    private const float MinimumProtectedRadius = 96f;
 
     private static readonly HashSet<string> ProtectedLocations = LocationDefinitions.Ports
         .Concat(LocationDefinitions.Traders)
+        .Concat(LocationDefinitions.Trainers)
         .Select(location => Helpers.GetNormalizedName(location.Name))
         .ToHashSet();
+
+    private static readonly string[] ProtectedAnchorPrefabs = LocationDefinitions.Traders
+        .Select(location => location.Name + "_Vendor")
+        .Concat(LocationDefinitions.Trainers.Select(location => location.Name + "_Trainer"))
+        .ToArray();
+
+    private static readonly List<ZDO> AnchorZdos = new();
+    private static readonly List<Vector3> ProtectedAnchorPositions = new();
+    private static int protectedAnchorPositionsFrame = -1;
 
     [UsedImplicitly]
     private static void Postfix(Location __instance)
@@ -30,17 +43,128 @@ public static class ProtectedLocationWearNTearPatch
         }
     }
 
-    private static void SetProtectedPieceHealthOnce(WearNTear wearNTear)
+    internal static void SetProtectedPieceHealthOnce(WearNTear wearNTear)
     {
         if (wearNTear == null) return;
-        if (wearNTear.m_health == ProtectedPieceHealth) return;
-
-        wearNTear.m_health = ProtectedPieceHealth;
 
         ZNetView view = wearNTear.GetComponent<ZNetView>();
-        if (view == null || !view.IsValid() || !view.IsOwner()) return;
+        if (view == null || !view.IsValid())
+        {
+            wearNTear.m_health = ProtectedPieceHealth;
+            return;
+        }
+
+        float currentZdoHealth = view.GetZDO().GetFloat(ZDOVars.s_health, wearNTear.m_health);
+        if (Mathf.Approximately(wearNTear.m_health, ProtectedPieceHealth) &&
+            Mathf.Approximately(currentZdoHealth, ProtectedPieceHealth))
+        {
+            return;
+        }
+
+        wearNTear.m_health = ProtectedPieceHealth;
+        if (!view.IsOwner()) return;
 
         view.GetZDO().Set(ZDOVars.s_health, ProtectedPieceHealth);
         view.InvokeRPC(ZNetView.Everybody, "RPC_HealthChanged", ProtectedPieceHealth);
+    }
+
+    internal static bool IsProtectedLocationPiece(WearNTear wearNTear)
+    {
+        if (wearNTear == null) return false;
+
+        Piece piece = wearNTear.GetComponent<Piece>();
+        if (piece != null && piece.IsPlacedByPlayer()) return false;
+
+        ZoneSystem zoneSystem = ZoneSystem.instance;
+        if (zoneSystem == null) return false;
+
+        Vector3 position = wearNTear.transform.position;
+        foreach (ZoneSystem.LocationInstance locationInstance in zoneSystem.GetLocationList())
+        {
+            if (!IsProtectedLocationName(locationInstance.m_location)) continue;
+
+            float radius = Mathf.Max(locationInstance.m_location.m_exteriorRadius, locationInstance.m_location.m_interiorRadius);
+            radius = Mathf.Max(radius, MinimumProtectedRadius);
+            if (global::Utils.DistanceXZ(position, locationInstance.m_position) <= radius) return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsProtectedLocationName(ZoneSystem.ZoneLocation location)
+    {
+        if (ProtectedLocations.Contains(Helpers.GetNormalizedName(location.m_name))) return true;
+        if (ProtectedLocations.Contains(Helpers.GetNormalizedName(location.m_prefabName))) return true;
+
+        string prefabName = location.m_prefab.Name;
+        return !string.IsNullOrEmpty(prefabName) && ProtectedLocations.Contains(Helpers.GetNormalizedName(prefabName));
+    }
+
+    internal static bool IsNearProtectedAnchor(Vector3 position)
+    {
+        if (ZDOMan.instance == null) return false;
+
+        RefreshProtectedAnchorPositions();
+        foreach (Vector3 anchorPosition in ProtectedAnchorPositions)
+        {
+            if (global::Utils.DistanceXZ(position, anchorPosition) <= MinimumProtectedRadius) return true;
+        }
+
+        return false;
+    }
+
+    private static void RefreshProtectedAnchorPositions()
+    {
+        if (protectedAnchorPositionsFrame == Time.frameCount) return;
+
+        protectedAnchorPositionsFrame = Time.frameCount;
+        ProtectedAnchorPositions.Clear();
+        foreach (ZDO port in ShipmentManager.GetPorts())
+        {
+            ProtectedAnchorPositions.Add(port.GetPosition());
+        }
+
+        foreach (string anchorPrefab in ProtectedAnchorPrefabs)
+        {
+            AnchorZdos.Clear();
+            int index = 0;
+            while (!ZDOMan.instance.GetAllZDOsWithPrefabIterative(anchorPrefab, AnchorZdos, ref index))
+            {
+            }
+
+            foreach (ZDO anchor in AnchorZdos)
+            {
+                ProtectedAnchorPositions.Add(anchor.GetPosition());
+            }
+        }
+    }
+}
+
+[HarmonyPatch(typeof(WearNTear), "Awake")]
+public static class ProtectedLocationWearNTearAwakePatch
+{
+    [UsedImplicitly]
+    private static void Postfix(WearNTear __instance)
+    {
+        __instance.StartCoroutine(SetProtectedHealthWhenAnchorsAreReady(__instance));
+    }
+
+    private static IEnumerator SetProtectedHealthWhenAnchorsAreReady(WearNTear wearNTear)
+    {
+        float[] delays = { 0f, 2f, 8f };
+        foreach (float delay in delays)
+        {
+            if (delay > 0f) yield return new WaitForSeconds(delay);
+
+            if (wearNTear == null) yield break;
+            if (!ProtectedLocationWearNTearPatch.IsProtectedLocationPiece(wearNTear) &&
+                !ProtectedLocationWearNTearPatch.IsNearProtectedAnchor(wearNTear.transform.position))
+            {
+                continue;
+            }
+
+            ProtectedLocationWearNTearPatch.SetProtectedPieceHealthOnce(wearNTear);
+            yield break;
+        }
     }
 }

--- a/More World Locations_AIO/Src/Ports/src/Commands.cs
+++ b/More World Locations_AIO/Src/Ports/src/Commands.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using static Terminal;
 
@@ -55,63 +54,5 @@ public static class Commands
                 if (!Player.m_localPlayer) return;
                 Player.m_localPlayer.ResetKnownPorts();
             });
-
-        ConsoleCommand protectedHealthCheck = new ConsoleCommand("mwl_protected_health_check",
-            "reports protected MWL location piece health near the player",
-            args =>
-            {
-                if (!Player.m_localPlayer)
-                {
-                    args.Context.AddString("ERROR: No local player");
-                    return;
-                }
-
-                float radius = args.Length > 1 && float.TryParse(args[1], out float parsedRadius) ? parsedRadius : 80f;
-                Vector3 playerPosition = Player.m_localPlayer.transform.position;
-                List<WearNTear> nearbyWorldPieces = WearNTear.GetAllInstances()
-                    .Where(wearNTear => wearNTear != null)
-                    .Where(wearNTear => Vector3.Distance(playerPosition, wearNTear.transform.position) <= radius)
-                    .Where(wearNTear =>
-                    {
-                        Piece piece = wearNTear.GetComponent<Piece>();
-                        return piece == null || !piece.IsPlacedByPlayer();
-                    })
-                    .ToList();
-
-                List<WearNTear> protectedPieces = nearbyWorldPieces
-                    .Where(ProtectedLocationWearNTearPatch.IsProtectedLocationPiece)
-                    .ToList();
-
-                (int worldHealth9999, List<string> worldSamples) = CountProtectedHealth(nearbyWorldPieces);
-                (int protectedHealth9999, List<string> protectedSamples) = CountProtectedHealth(protectedPieces);
-
-                args.Context.AddString(
-                    $"MWL protected health check radius={radius:0.#} worldTotal={nearbyWorldPieces.Count} worldHealth9999={worldHealth9999} worldFailing={nearbyWorldPieces.Count - worldHealth9999} worldSamples={string.Join(",", worldSamples)} protectedTotal={protectedPieces.Count} protectedHealth9999={protectedHealth9999} protectedFailing={protectedPieces.Count - protectedHealth9999} protectedSamples={string.Join(",", protectedSamples)}");
-            });
-    }
-
-    private static (int health9999, List<string> samples) CountProtectedHealth(List<WearNTear> pieces)
-    {
-        int health9999 = 0;
-        List<string> samples = new List<string>();
-        foreach (WearNTear wearNTear in pieces)
-        {
-            ZNetView view = wearNTear.GetComponent<ZNetView>();
-            float health = view != null && view.IsValid()
-                ? view.GetZDO().GetFloat(ZDOVars.s_health, wearNTear.m_health)
-                : wearNTear.m_health;
-
-            if (Mathf.Approximately(health, 9999f) && Mathf.Approximately(wearNTear.m_health, 9999f))
-            {
-                health9999++;
-            }
-
-            if (samples.Count >= 12) continue;
-
-            string prefab = wearNTear.name.Replace("(Clone)", "").Trim();
-            samples.Add($"{prefab}:{health:0.##}/{wearNTear.m_health:0.##}");
-        }
-
-        return (health9999, samples);
     }
 }

--- a/More World Locations_AIO/Src/Ports/src/Commands.cs
+++ b/More World Locations_AIO/Src/Ports/src/Commands.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using static Terminal;
 
@@ -54,5 +55,63 @@ public static class Commands
                 if (!Player.m_localPlayer) return;
                 Player.m_localPlayer.ResetKnownPorts();
             });
+
+        ConsoleCommand protectedHealthCheck = new ConsoleCommand("mwl_protected_health_check",
+            "reports protected MWL location piece health near the player",
+            args =>
+            {
+                if (!Player.m_localPlayer)
+                {
+                    args.Context.AddString("ERROR: No local player");
+                    return;
+                }
+
+                float radius = args.Length > 1 && float.TryParse(args[1], out float parsedRadius) ? parsedRadius : 80f;
+                Vector3 playerPosition = Player.m_localPlayer.transform.position;
+                List<WearNTear> nearbyWorldPieces = WearNTear.GetAllInstances()
+                    .Where(wearNTear => wearNTear != null)
+                    .Where(wearNTear => Vector3.Distance(playerPosition, wearNTear.transform.position) <= radius)
+                    .Where(wearNTear =>
+                    {
+                        Piece piece = wearNTear.GetComponent<Piece>();
+                        return piece == null || !piece.IsPlacedByPlayer();
+                    })
+                    .ToList();
+
+                List<WearNTear> protectedPieces = nearbyWorldPieces
+                    .Where(ProtectedLocationWearNTearPatch.IsProtectedLocationPiece)
+                    .ToList();
+
+                (int worldHealth9999, List<string> worldSamples) = CountProtectedHealth(nearbyWorldPieces);
+                (int protectedHealth9999, List<string> protectedSamples) = CountProtectedHealth(protectedPieces);
+
+                args.Context.AddString(
+                    $"MWL protected health check radius={radius:0.#} worldTotal={nearbyWorldPieces.Count} worldHealth9999={worldHealth9999} worldFailing={nearbyWorldPieces.Count - worldHealth9999} worldSamples={string.Join(",", worldSamples)} protectedTotal={protectedPieces.Count} protectedHealth9999={protectedHealth9999} protectedFailing={protectedPieces.Count - protectedHealth9999} protectedSamples={string.Join(",", protectedSamples)}");
+            });
+    }
+
+    private static (int health9999, List<string> samples) CountProtectedHealth(List<WearNTear> pieces)
+    {
+        int health9999 = 0;
+        List<string> samples = new List<string>();
+        foreach (WearNTear wearNTear in pieces)
+        {
+            ZNetView view = wearNTear.GetComponent<ZNetView>();
+            float health = view != null && view.IsValid()
+                ? view.GetZDO().GetFloat(ZDOVars.s_health, wearNTear.m_health)
+                : wearNTear.m_health;
+
+            if (Mathf.Approximately(health, 9999f) && Mathf.Approximately(wearNTear.m_health, 9999f))
+            {
+                health9999++;
+            }
+
+            if (samples.Count >= 12) continue;
+
+            string prefab = wearNTear.name.Replace("(Clone)", "").Trim();
+            samples.Add($"{prefab}:{health:0.##}/{wearNTear.m_health:0.##}");
+        }
+
+        return (health9999, samples);
     }
 }

--- a/More World Locations_AIO/Src/Traders/TraderPrefabs.cs
+++ b/More World Locations_AIO/Src/Traders/TraderPrefabs.cs
@@ -11,6 +11,25 @@ namespace More_World_Locations_AIO.Traders;
 
 public class TraderPrefabs
 {
+    public static readonly string[] TraderPrefabNames =
+    {
+        "MWL_PlainsTavern1_Vendor",
+        "MWL_PlainsCamp1_Vendor",
+        "MWL_BlackForestBlacksmith1_Vendor",
+        "MWL_BlackForestBlacksmith2_Vendor",
+        "MWL_MountainsBlacksmith1_Vendor",
+        "MWL_MistlandsBlacksmith1_Vendor",
+        "MWL_OceanTavern1_Vendor"
+    };
+
+    public static readonly string[] TrainerPrefabNames =
+    {
+        "MWL_MeadowsTrainer1_Trainer",
+        "MWL_SwampTrainer1_Trainer",
+        "MWL_PlainsTrainer1_Trainer",
+        "MWL_MistTrainer1_Trainer"
+    };
+
     private static Dictionary<string, List<Trader.TradeItem>> traderItemsCache = new Dictionary<string, List<Trader.TradeItem>>();
 
     public static void AddTraderPrefabs()

--- a/More World Locations_AIO/Src/Traders/TraderPrefabs.cs
+++ b/More World Locations_AIO/Src/Traders/TraderPrefabs.cs
@@ -11,25 +11,6 @@ namespace More_World_Locations_AIO.Traders;
 
 public class TraderPrefabs
 {
-    public static readonly string[] TraderPrefabNames =
-    {
-        "MWL_PlainsTavern1_Vendor",
-        "MWL_PlainsCamp1_Vendor",
-        "MWL_BlackForestBlacksmith1_Vendor",
-        "MWL_BlackForestBlacksmith2_Vendor",
-        "MWL_MountainsBlacksmith1_Vendor",
-        "MWL_MistlandsBlacksmith1_Vendor",
-        "MWL_OceanTavern1_Vendor"
-    };
-
-    public static readonly string[] TrainerPrefabNames =
-    {
-        "MWL_MeadowsTrainer1_Trainer",
-        "MWL_SwampTrainer1_Trainer",
-        "MWL_PlainsTrainer1_Trainer",
-        "MWL_MistTrainer1_Trainer"
-    };
-
     private static Dictionary<string, List<Trader.TradeItem>> traderItemsCache = new Dictionary<string, List<Trader.TradeItem>>();
 
     public static void AddTraderPrefabs()


### PR DESCRIPTION
## Summary
- protects ports, traders, and trainers at 9999 health
- adds owner-side delayed protection using MWL port/trader/trainer anchor ZDOs for existing loaded pieces
- adds an MWL diagnostic command for protected health validation

## Validation
- dotnet build "More World Locations_AIO/More World Locations_AIO.csproj" -c Debug
- Valdev + valnet-client-02 live validation:
  - Port: worldHealth9999=496, worldFailing=0
  - Trader: worldHealth9999=3082, worldFailing=0
  - Trainer: worldHealth9999=904, worldFailing=0